### PR TITLE
Add `include-ref` option

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -115,6 +115,7 @@ jobs:
       uses: ./
       with:
         filter: ${{ matrix.filter }}
+        include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
         repository: ${{ matrix.repository }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,26 +70,26 @@ jobs:
       matrix:
         include:
           - name: Should return the preceding tag from a SHA.
-            exclude-ref: ""
             filter: ""
+            include-ref: ""
             ref: 7f6f9a02a5f985b460f60b8dbe6c11294695c96f
             repository: ""
             expected-tag: release-0.0.0
-          - name: Should return this tag if the ref is a tag that matches the filter.
-            exclude-ref: ""
+          - name: Should return the preceding tag from a tag.
             filter: ^release-.+$
-            ref: release-0.0.2
-            repository: ""
-            expected-tag: release-0.0.2
-          - name: Should return the preceding tag if the ref is a tag that matches the filter, but exclude-ref is true.
-            exclude-ref: true
-            filter: ^release-.+$
+            include-ref: ""
             ref: release-0.0.2
             repository: ""
             expected-tag: release-0.0.1
+          - name: Should return this tag if ref matches the filter and include-ref is set to true.
+            filter: ^release-.+$
+            include-ref: true
+            ref: release-0.0.2
+            repository: ""
+            expected-tag: release-0.0.2
           - name: Should return an empty string if no preceding tag exists.
-            exclude-ref: ""
             filter: ""
+            include-ref: ""
             ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
             repository: ""
             expected-tag: ""

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,22 +69,26 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Get preceding tag from a SHA
+          - name: Should return the preceding tag from a SHA.
+            exclude-ref: ""
             filter: ""
             ref: 7f6f9a02a5f985b460f60b8dbe6c11294695c96f
             repository: ""
             expected-tag: release-0.0.0
-          - name: Get preceding tag from a tag
-            filter: ""
+          - name: Should return this tag if the ref is a tag that matches the filter.
+            exclude-ref: ""
+            filter: ^release-.+$
             ref: release-0.0.2
             repository: ""
             expected-tag: release-0.0.2
-          - name: Get preceding tag from a tag, ignoring the tag
-            filter: ^(?!.*(release-0\.0\.2)).+$
+          - name: Should return the preceding tag if the ref is a tag that matches the filter, but exclude-ref is true.
+            exclude-ref: true
+            filter: ^release-.+$
             ref: release-0.0.2
             repository: ""
             expected-tag: release-0.0.1
-          - name: No preceding tag exists
+          - name: Should return an empty string if no preceding tag exists.
+            exclude-ref: ""
             filter: ""
             ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
             repository: ""

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ This action functions similar to [`git describe`][git-describe-link] by finding 
 Although this project publishes version tags, we strongly recommend [pinning this action to a full-length commit SHA][security-sha-pinning-link]. You can get the SHA of the latest release from the [latest release page][latest-release-link] by clicking the commit link, then and copying the SHA from the URL.
 
 ## Inputs
-| Name         | Type   | Default                    | Description                                                                 |
-|--------------|--------|----------------------------|-----------------------------------------------------------------------------|
-| `repository` | String | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
-| `ref`        | String | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
-| `filter`     | String | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
-| `token`      | String | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
+| Name          | Type    | Default                    | Description                                                                 |
+|---------------|---------|----------------------------|-----------------------------------------------------------------------------|
+| `repository`  | String  | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
+| `ref`         | String  | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
+| `filter`      | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
+| `exclude-ref` | Boolean | `false`                    | Disqualify candidate tags pointing to `ref`.                                |
+| `token`       | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
 
 ## Outputs
 | Name  | Type   | Description  |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Although this project publishes version tags, we strongly recommend [pinning thi
 | `repository`  | String  | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
 | `ref`         | String  | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
 | `filter`      | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
-| `exclude-ref` | Boolean | `false`                    | Disqualify candidate tags pointing to `ref`.                                |
+| `include-ref` | Boolean | `false`                    | Consider candidate tags pointing to `ref`.                                  |
 | `token`       | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ runs:
   main: dist/index.js
 
 inputs:
-  exclude-ref:
-    description: Disqualify candidate tags pointing to `ref`.
-    default: "false"
-    required: false
   filter:
     description: A regular expression used to filter candidate tag names.
     default: ^.+$
+    required: false
+  include-ref:
+    description: Consider candidate tags pointing to `ref`.
+    default: "false"
     required: false
   ref:
     description: The branch, tag, or SHA to find the preceding tag from.

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,19 @@
 name: Preceding Tag Action
-description: Finds the most recent tag matching the given pattern that is reachable from this commit.
+author: AJ Granowski
+description: Find the most recent tag that is reachable from a commit.
 runs:
   using: node24
   main: dist/index.js
 
 inputs:
+  exclude-ref:
+    description: Disqualify candidate tags pointing to `ref`.
+    default: "false"
+    required: false
   filter:
     description: A regular expression used to filter candidate tag names.
     default: ^.+$
-    required: true
+    required: false
   ref:
     description: The branch, tag, or SHA to find the preceding tag from.
     default: ${{ github.sha }}
@@ -16,11 +21,11 @@ inputs:
   repository:
     description: Repository name with owner. For example, AJGranowski/preceding-tag-action
     default: ${{ github.repository }}
-    required: true
+    required: false
   token:
     description: Personal access token (PAT) used to fetch the tags.
     default: ${{ github.token }}
-    required: true
+    required: false
 
 outputs:
   tag:

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -18,17 +18,6 @@ class Input {
     }
 
     /**
-     * Return the exclude-ref option, defaults to false.
-     */
-    getExcludeRef(): boolean {
-        if (this.getInput("exclude-ref").length === 0) {
-            return false;
-        }
-
-        return this.getBooleanInput("exclude-ref");
-    }
-
-    /**
      * Get the tag filtering regular expression, defaults to matching every non-zero string.
      */
     getFilter(): RegExp {
@@ -38,6 +27,17 @@ class Input {
         }
 
         return new RegExp(filterString);
+    }
+
+    /**
+     * Return the include-ref option, defaults to false.
+     */
+    getIncludeRef(): boolean {
+        if (this.getInput("include-ref").length === 0) {
+            return false;
+        }
+
+        return this.getBooleanInput("include-ref");
     }
 
     /**

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -56,6 +56,18 @@ class Input {
             repo: matcher.groups.repo
         };
     }
+
+    /**
+     * Return the token if it exists, or undefined.
+     */
+    getToken(): string | undefined {
+        const token = this.getInput("token");
+        if (token.length === 0) {
+            return undefined;
+        }
+
+        return token;
+    }
 }
 
 export { Input };

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,21 +1,35 @@
-import type { getInput } from "@actions/core";
+import type { getBooleanInput, getInput } from "@actions/core";
 import type { context } from "@actions/github";
 
 import type { Repository } from "./Repository";
 
+type core_getBooleanInput = typeof getBooleanInput;
 type core_getInput = typeof getInput;
 type github_context = typeof context;
 
 class Input {
-    private readonly getInput: core_getInput;
     private readonly context: github_context;
-    constructor(getInput: core_getInput, context: github_context) {
+    private readonly getBooleanInput: core_getBooleanInput;
+    private readonly getInput: core_getInput;
+    constructor(getInput: core_getInput, getBooleanInput: core_getBooleanInput, context: github_context) {
         this.context = context;
+        this.getBooleanInput = getBooleanInput;
         this.getInput = getInput;
     }
 
     /**
-     * Get the tag filtering regular expression if provided.
+     * Return the exclude-ref option, defaults to false.
+     */
+    getExcludeRef(): boolean {
+        if (this.getInput("exclude-ref").length === 0) {
+            return false;
+        }
+
+        return this.getBooleanInput("exclude-ref");
+    }
+
+    /**
+     * Get the tag filtering regular expression, defaults to matching every non-zero string.
      */
     getFilter(): RegExp {
         const filterString = this.getInput("filter");
@@ -27,7 +41,7 @@ class Input {
     }
 
     /**
-     * Get the ref to get the preceding tag of.
+     * Get the ref to get the preceding tag of. Defaults to HEAD if not supplied for some reason.
      */
     getRef(): string {
         const ref = this.getInput("ref");

--- a/src/fetchPrecedingTag.ts
+++ b/src/fetchPrecedingTag.ts
@@ -8,7 +8,7 @@ interface TagDifference {
 type GitRef = string;
 interface Options {
     filter?: RegExp;
-    excludeRef?: boolean;
+    includeRef?: boolean;
 }
 
 /**
@@ -22,7 +22,7 @@ interface Options {
 async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, options?: Options): Promise<string | null> {
     const optionsWithDefaults = {
         filter: /^.+$/,
-        excludeRef: false,
+        includeRef: false,
         ...options
     } satisfies Required<Options>;
 
@@ -40,11 +40,11 @@ async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, options?: O
                 return false;
             }
 
-            if (optionsWithDefaults.excludeRef) {
-                return x.commitDifference > 0;
+            if (optionsWithDefaults.includeRef) {
+                return x.commitDifference >= 0;
             }
 
-            return x.commitDifference >= 0;
+            return x.commitDifference > 0;
         })
         .reduce((prev: TagDifference | null, next: TagDifference) => {
             if (prev == null) {

--- a/src/fetchPrecedingTag.ts
+++ b/src/fetchPrecedingTag.ts
@@ -6,6 +6,10 @@ interface TagDifference {
 }
 
 type GitRef = string;
+interface Options {
+    filter?: RegExp;
+    excludeRef?: boolean;
+}
 
 /**
  * This function finds the most recent tag that is reachable from a commit.
@@ -15,9 +19,14 @@ type GitRef = string;
  *
  * Will reject if the API is unavailable, or if the reference does not exist.
  */
-async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, filter?: RegExp): Promise<string | null> {
-    filter = filter ?? /^.+$/;
-    const allTags = await githubAPI.fetchAllTags(filter);
+async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, options?: Options): Promise<string | null> {
+    const optionsWithDefaults = {
+        filter: /^.+$/,
+        excludeRef: false,
+        ...options
+    } satisfies Required<Options>;
+
+    const allTags = await githubAPI.fetchAllTags(optionsWithDefaults.filter);
     const tagDistances = await Promise.all(allTags.map(async (tag) => {
         return {
             tags: [tag],
@@ -26,7 +35,17 @@ async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, filter?: Re
     }));
 
     const precedingTag = tagDistances
-        .filter((x) => !isNaN(x.commitDifference) && x.commitDifference >= 0)
+        .filter((x) => {
+            if (isNaN(x.commitDifference)) {
+                return false;
+            }
+
+            if (optionsWithDefaults.excludeRef) {
+                return x.commitDifference > 0;
+            }
+
+            return x.commitDifference >= 0;
+        })
         .reduce((prev: TagDifference | null, next: TagDifference) => {
             if (prev == null) {
                 return next;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,16 @@ import { Input } from "./Input";
 
 try {
     await (async (): Promise<void> => {
-        const input: Input = new Input(core.getInput, context);
+        const input: Input = new Input(core.getInput, core.getBooleanInput, context);
         const octokit: Octokit = new Octokit({
             auth: input.getToken()
         });
 
         const githubAPI = new GitHubAPI(octokit, input.getRepository());
-        const precedingTag = await fetchPrecedingTag(githubAPI, input.getRef(), input.getFilter());
+        const precedingTag = await fetchPrecedingTag(githubAPI, input.getRef(), {
+            filter: input.getFilter(),
+            excludeRef: input.getExcludeRef()
+        });
 
         if (precedingTag == null) {
             core.setOutput("tag", "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ try {
     await (async (): Promise<void> => {
         const input: Input = new Input(core.getInput, context);
         const octokit: Octokit = new Octokit({
-            auth: core.getInput("token")
+            auth: input.getToken()
         });
 
         const githubAPI = new GitHubAPI(octokit, input.getRepository());

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ try {
         const githubAPI = new GitHubAPI(octokit, input.getRepository());
         const precedingTag = await fetchPrecedingTag(githubAPI, input.getRef(), {
             filter: input.getFilter(),
-            excludeRef: input.getExcludeRef()
+            includeRef: input.getIncludeRef()
         });
 
         if (precedingTag == null) {


### PR DESCRIPTION
## What are these changes?
This change adds the `include-ref` option.

## Why are these changes being made?
Being called ***Preceding Tag Action***, it's unintuitive that this action returns the starting commit if it's tagged. To address this issue while preserving `git describe` behavior, this change introduces the `include-ref` flag.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
