### PR TITLE
Rename `filter` option to `regex`

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -260,7 +260,7 @@ jobs:
       id: preceding-tag
       uses: AJGranowski/preceding-tag-action@80c580ff81c21e3212bdf3e447a41837e8861bab # v0.0.6
       with:
-        filter: ${{ env.RELEASE_REGEX }}
+        regex: ${{ env.RELEASE_REGEX }}
 
     - name: Increment And Create Release Tag
       id: increment-tag

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
     - uses: ./
       id: preceding-release-tag
       with:
-        filter: ^release-.+$
+        regex: ^release-.+$
 
     - env:
         PRECEDING_RELEASE_TAG: ${{ steps.preceding-release-tag.outputs.tag }}
@@ -70,27 +70,27 @@ jobs:
       matrix:
         include:
           - name: Should return the preceding tag from a SHA.
-            filter: ""
             include-ref: ""
             ref: 7f6f9a02a5f985b460f60b8dbe6c11294695c96f
+            regex: ""
             repository: ""
             expected-tag: release-0.0.0
           - name: Should return the preceding tag from a tag.
-            filter: ^release-.+$
             include-ref: ""
             ref: release-0.0.2
+            regex: ^release-.+$
             repository: ""
             expected-tag: release-0.0.1
           - name: Should return this tag if ref matches the filter and include-ref is set to true.
-            filter: ^release-.+$
             include-ref: true
             ref: release-0.0.2
+            regex: ^release-.+$
             repository: ""
             expected-tag: release-0.0.2
           - name: Should return an empty string if no preceding tag exists.
-            filter: ""
             include-ref: ""
             ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
+            regex: ""
             repository: ""
             expected-tag: ""
 
@@ -114,9 +114,9 @@ jobs:
       id: preceding-tag-local
       uses: ./
       with:
-        filter: ${{ matrix.filter }}
         include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
+        regex: ${{ matrix.regex }}
         repository: ${{ matrix.repository }}
 
     - name: Compare Output

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -14,20 +14,24 @@ jobs:
       matrix:
         include:
           - name: Empty inputs
-            filter: ""
+            include-ref: ""
             ref: ""
+            regex: ""
             repository: ""
           - name: Filter for release-* tags
-            filter: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+            include-ref: ""
             ref: ""
+            regex: ^release-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
             repository: ""
           - name: Starting from a different commit
-            filter: ""
+            include-ref: ""
             ref: 7f6f9a02a5f985b460f60b8dbe6c11294695c96f
+            regex: ""
             repository: ""
           - name: Using a different repository
-            filter: ""
+            include-ref: ""
             ref: ""
+            regex: ""
             repository: "github/markup"
 
     steps:
@@ -50,16 +54,18 @@ jobs:
       id: preceding-tag-local
       uses: ./
       with:
-        filter: ${{ matrix.filter }}
+        include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
+        regex: ${{ matrix.regex }}
         repository: ${{ matrix.repository }}
 
     - name: Run Published Action
       id: preceding-tag-published
       uses: AJGranowski/preceding-tag-action@80c580ff81c21e3212bdf3e447a41837e8861bab # v0.0.6
       with:
-        filter: ${{ matrix.filter }}
+        include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
+        regex: ${{ matrix.regex }}
         repository: ${{ matrix.repository }}
 
     - name: Expect Outputs To Be Equal

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Although this project publishes version tags, we strongly recommend [pinning thi
 |---------------|---------|----------------------------|-----------------------------------------------------------------------------|
 | `repository`  | String  | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
 | `ref`         | String  | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
-| `filter`      | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
+| `regex`       | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
 | `include-ref` | Boolean | `false`                    | Consider candidate tags pointing to `ref`.                                  |
 | `token`       | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This action functions similar to [`git describe`][git-describe-link] by finding 
 - uses: AJGranowski/preceding-tag-action@▒▒▒▒▒▒▒▒▒▒▒▒▒ COMMIT SHA ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ # vX.Y.Z
   id: preceding-release-tag
   with:
-    filter: ^release-.+$
+    regex: ^release-.+$
 
 - env:
     PRECEDING_RELEASE_TAG: ${{ steps.preceding-release-tag.outputs.tag }}

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,6 @@ runs:
   main: dist/index.js
 
 inputs:
-  filter:
-    description: A regular expression used to filter candidate tag names.
-    default: ^.+$
-    required: false
   include-ref:
     description: Consider candidate tags pointing to `ref`.
     default: "false"
@@ -18,6 +14,10 @@ inputs:
     description: The branch, tag, or SHA to find the preceding tag from.
     default: ${{ github.sha }}
     required: true
+  regex:
+    description: A regular expression used to filter candidate tag names.
+    default: ^.+$
+    required: false
   repository:
     description: Repository name with owner. For example, AJGranowski/preceding-tag-action
     default: ${{ github.repository }}

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -21,7 +21,7 @@ class Input {
      * Get the tag filtering regular expression, defaults to matching every non-zero string.
      */
     getFilter(): RegExp {
-        const filterString = this.getInput("filter");
+        const filterString = this.getInput("regex");
         if (filterString.length === 0) {
             return /^.+$/;
         }


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
Rename the `filter` option to `regex`.

## Why are these changes being made?
This gives the action more flexibility in the future if we wanted to add other filtering types, such as glob.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
