### PR TITLE
Increase `fetchPrecedingTag` coverage

### DIFF
--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -61,15 +61,26 @@ describe("fetchPrecedingTag", () => {
     });
 
     test("should compare each tag against the target ref", async () => {
+        const tags = ["tag1", "tag2", "tag3"];
         const mockGithubAPI = mock<GitHubAPI>({
-            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
+            fetchAllTags: () => Promise.resolve(tags)
         });
 
         await fetchPrecedingTag(mockGithubAPI, "HEAD");
 
-        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag1", "HEAD");
-        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag2", "HEAD");
-        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag3", "HEAD");
+        const nonHeadArgs = [];
+        for (const call of mockGithubAPI.fetchCommitDifference.mock.calls) {
+            expect(call.length === 2);
+            expect(call).contains("HEAD");
+            if (call[0] === "HEAD") {
+                nonHeadArgs.push(call[1]);
+            } else {
+                nonHeadArgs.push(call[0]);
+            }
+        }
+
+        expect(nonHeadArgs).containSubset(tags);
+        expect(tags).containSubset(nonHeadArgs);
     });
 
     test("should return the closest preceding tag", async () => {

--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -1,10 +1,4 @@
-import {
-    describe,
-    expect,
-    test,
-    vi
-} from "vitest";
-
+import { describe, expect, test } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { GitHubAPI } from "../src/GitHubAPI";
@@ -21,7 +15,7 @@ describe("fetchPrecedingTag", () => {
 
     test("should compare each tag against the target ref", async () => {
         const mockGithubAPI = mock<GitHubAPI>({
-            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"]),
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
         });
 
         await fetchPrecedingTag(mockGithubAPI, "HEAD");
@@ -115,7 +109,7 @@ describe("fetchPrecedingTag", () => {
 
         mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
             const committerCommitDate = ({
-                "tag1": "2025-08-14T01:02:03Z",
+                "tag1": "2025-08-14T01:02:03Z"
             })[tag];
 
             return Promise.resolve({
@@ -127,7 +121,7 @@ describe("fetchPrecedingTag", () => {
 
         mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
             const committerCommitDate = ({
-                "tag2": "2025-08-14T01:02:03Z",
+                "tag2": "2025-08-14T01:02:03Z"
             })[tag];
 
             return Promise.resolve({

--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -4,6 +4,53 @@ import { mock } from "vitest-mock-extended";
 import type { GitHubAPI } from "../src/GitHubAPI";
 import { fetchPrecedingTag } from "../src/fetchPrecedingTag";
 
+interface TestParameter {
+    tag1Author?: string,
+    tag1Committer?: string,
+    tag2Author?: string,
+    tag2Committer?: string
+}
+
+interface GenerateTestParameterSetOptions {
+    tag1Authors: (string | undefined)[],
+    tag1Committers: (string | undefined)[],
+    tag2Authors: (string | undefined)[],
+    tag2Committers: (string | undefined)[]
+}
+
+function generateTestParameterSet(options: GenerateTestParameterSetOptions): Set<TestParameter> {
+    const result = new Set<TestParameter>();
+    /* eslint max-depth: off */
+    for (const tag1Author of options.tag1Authors) {
+        for (const tag1Committer of options.tag1Committers) {
+            for (const tag2Author of options.tag2Authors) {
+                for (const tag2Committer of options.tag2Committers) {
+                    result.add({
+                        tag1Author: tag1Author,
+                        tag1Committer: tag1Committer,
+                        tag2Author: tag2Author,
+                        tag2Committer: tag2Committer
+                    });
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+function makeFetchCommitDifferenceProcedure(target: string, differences: Record<string, number>): (a: string, b: string) => Promise<number> {
+    return (a: string, b: string) => {
+        if (b === target) {
+            return Promise.resolve(differences[a] ?? NaN);
+        } else if (a === target) {
+            return Promise.resolve(-(differences[b] ?? NaN));
+        }
+
+        throw new Error(`Neither compared tags match the target tag ${target}`);
+    };
+}
+
 describe("fetchPrecedingTag", () => {
     test("should return null if the repo has no tags", async () => {
         const mockGithubAPI = mock<GitHubAPI>({
@@ -30,109 +77,106 @@ describe("fetchPrecedingTag", () => {
             fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
         });
 
-        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
-            const abTable: Record<string, number> = {
-                "tag1": 3,
-                "tag2": 2,
-                "tag3": -1
-            };
-
-            if (b === "HEAD") {
-                return Promise.resolve(abTable[a] ?? NaN);
-            } else if (a === "HEAD") {
-                return Promise.resolve(-(abTable[b] ?? NaN));
-            }
-
-            return Promise.resolve(NaN);
-        });
+        mockGithubAPI.fetchCommitDifference.mockImplementation(makeFetchCommitDifferenceProcedure("HEAD", {
+            "tag1": 3,
+            "tag2": 2,
+            "tag3": -1
+        }));
 
         expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
     });
 
-    test("should return the latest commit date of equal distance tags", async () => {
-        const mockGithubAPI = mock<GitHubAPI>({
-            fetchAllTags: () => Promise.resolve(["tag1", "tag2"])
-        });
+    describe("same commit difference, different dates", () => {
+        const olderDate = "2025-09-09T06:23:06Z";
+        const earlierDate = "2025-09-10T03:37:12Z";
+        const tests = new Map<TestParameter, string>();
+        let tag1WinsSet = new Set<TestParameter>();
+        let tag2WinsSet = new Set<TestParameter>();
 
-        mockGithubAPI.fetchCommitDifference.mockResolvedValue(2);
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const committerCommitDate = ({
-                "tag1": "2025-09-10T03:37:12Z",
-                "tag2": "2025-09-09T06:23:06Z"
-            })[tag] ?? "1980-01-01T00:00:00Z";
+        tag1WinsSet = tag1WinsSet.union(generateTestParameterSet({
+            tag1Authors: [earlierDate, olderDate, undefined],
+            tag1Committers: [earlierDate],
+            tag2Authors: [earlierDate, olderDate, undefined],
+            tag2Committers: [olderDate, undefined]
+        }));
 
-            return Promise.resolve({
-                committer: committerCommitDate
+        tag1WinsSet = tag1WinsSet.union(generateTestParameterSet({
+            tag1Authors: [earlierDate, olderDate, undefined],
+            tag1Committers: [olderDate],
+            tag2Authors: [earlierDate, olderDate, undefined],
+            tag2Committers: [undefined]
+        }));
+
+        tag1WinsSet = tag1WinsSet.union(generateTestParameterSet({
+            tag1Authors: [earlierDate],
+            tag1Committers: [undefined],
+            tag2Authors: [olderDate, undefined],
+            tag2Committers: [undefined]
+        }));
+
+        tag2WinsSet = tag2WinsSet.union(generateTestParameterSet({
+            tag1Authors: [earlierDate, olderDate, undefined],
+            tag1Committers: [olderDate, undefined],
+            tag2Authors: [earlierDate, olderDate, undefined],
+            tag2Committers: [earlierDate]
+        }));
+
+        tag2WinsSet = tag2WinsSet.union(generateTestParameterSet({
+            tag1Authors: [earlierDate, olderDate, undefined],
+            tag1Committers: [undefined],
+            tag2Authors: [earlierDate, olderDate, undefined],
+            tag2Committers: [olderDate]
+        }));
+
+        tag2WinsSet = tag2WinsSet.union(generateTestParameterSet({
+            tag1Authors: [olderDate, undefined],
+            tag1Committers: [undefined],
+            tag2Authors: [earlierDate],
+            tag2Committers: [undefined]
+        }));
+
+        for (const testParameter of tag1WinsSet.values()) {
+            tests.set(testParameter, "tag1");
+        }
+
+        for (const testParameter of tag2WinsSet.values()) {
+            tests.set(testParameter, "tag2");
+        }
+
+        for (const testEntry of tests.entries()) {
+            const testParameters = testEntry[0];
+            const expectedResult = testEntry[1];
+            test(`should return ${expectedResult} with ${JSON.stringify(testParameters)}`, async () => {
+                const mockGithubAPI = mock<GitHubAPI>({
+                    fetchAllTags: () => Promise.resolve(["tag1", "tag2"])
+                });
+
+                const commitDates = {
+                    "tag1": {
+                        author: testParameters.tag1Author,
+                        committer: testParameters.tag1Committer
+                    },
+                    "tag2": {
+                        author: testParameters.tag2Author,
+                        committer: testParameters.tag2Committer
+                    }
+                };
+
+                mockGithubAPI.fetchCommitDifference.mockResolvedValue(1);
+                mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+                    if (!(tag in commitDates)) {
+                        return Promise.reject();
+                    }
+
+                    return Promise.resolve(commitDates[tag as keyof typeof commitDates]);
+                });
+
+                expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe(expectedResult);
             });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
-
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const committerCommitDate = ({
-                "tag1": "2025-09-09T06:23:06Z",
-                "tag2": "2025-09-10T03:37:12Z"
-            })[tag];
-
-            return Promise.resolve({
-                committer: committerCommitDate
-            });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
-
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const authorCommitDate = ({
-                "tag1": "2025-09-01T14:12:54Z",
-                "tag2": "2025-09-02T23:25:37Z"
-            })[tag];
-
-            return Promise.resolve({
-                author: authorCommitDate
-            });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
-
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const authorCommitDate = ({
-                "tag1": "2025-09-02T23:25:37Z",
-                "tag2": "2025-09-01T14:12:54Z"
-            })[tag];
-
-            return Promise.resolve({
-                author: authorCommitDate
-            });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
-
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const committerCommitDate = ({
-                "tag1": "2025-08-14T01:02:03Z"
-            })[tag];
-
-            return Promise.resolve({
-                committer: committerCommitDate
-            });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
-
-        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
-            const committerCommitDate = ({
-                "tag2": "2025-08-14T01:02:03Z"
-            })[tag];
-
-            return Promise.resolve({
-                committer: committerCommitDate
-            });
-        });
-
-        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
+        }
     });
 
-    test("should return something for basically equal tags", async () => {
+    test("should return non-null for equivalent tags", async () => {
         const mockGithubAPI = mock<GitHubAPI>({
             fetchAllTags: () => Promise.resolve(["tag1", "tag2"])
         });
@@ -148,21 +192,11 @@ describe("fetchPrecedingTag", () => {
             fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
         });
 
-        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
-            const abTable: Record<string, number> = {
-                "tag1": -1,
-                "tag2": 0,
-                "tag3": 1
-            };
-
-            if (b === "HEAD") {
-                return Promise.resolve(abTable[a] ?? NaN);
-            } else if (a === "HEAD") {
-                return Promise.resolve(-(abTable[b] ?? NaN));
-            }
-
-            return Promise.resolve(NaN);
-        });
+        mockGithubAPI.fetchCommitDifference.mockImplementation(makeFetchCommitDifferenceProcedure("HEAD", {
+            "tag1": -1,
+            "tag2": 0,
+            "tag3": 1
+        }));
 
         expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag3");
     });
@@ -172,21 +206,11 @@ describe("fetchPrecedingTag", () => {
             fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
         });
 
-        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
-            const abTable: Record<string, number> = {
-                "tag1": -1,
-                "tag2": 0,
-                "tag3": 1
-            };
-
-            if (b === "HEAD") {
-                return Promise.resolve(abTable[a] ?? NaN);
-            } else if (a === "HEAD") {
-                return Promise.resolve(-(abTable[b] ?? NaN));
-            }
-
-            return Promise.resolve(NaN);
-        });
+        mockGithubAPI.fetchCommitDifference.mockImplementation(makeFetchCommitDifferenceProcedure("HEAD", {
+            "tag1": -1,
+            "tag2": 0,
+            "tag3": 1
+        }));
 
         expect(await fetchPrecedingTag(mockGithubAPI, "HEAD", {includeRef: true})).toBe("tag2");
     });

--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, test } from "vitest";
+import {
+    describe,
+    expect,
+    test,
+    vi
+} from "vitest";
+
 import { mock } from "vitest-mock-extended";
 
 import type { GitHubAPI } from "../src/GitHubAPI";
@@ -11,5 +17,17 @@ describe("fetchPrecedingTag", () => {
         });
 
         expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBeNull();
+    });
+
+    test("should compare each tag against the target ref", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"]),
+        });
+
+        await fetchPrecedingTag(mockGithubAPI, "HEAD");
+
+        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag1", "HEAD");
+        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag2", "HEAD");
+        expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag3", "HEAD");
     });
 });

--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -30,4 +30,28 @@ describe("fetchPrecedingTag", () => {
         expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag2", "HEAD");
         expect(mockGithubAPI.fetchCommitDifference).toBeCalledWith("tag3", "HEAD");
     });
+
+    test("should return the closest preceding tag", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
+        });
+
+        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
+            const abTable: Record<string, number> = {
+                "tag1": 3,
+                "tag2": 2,
+                "tag3": -1
+            };
+
+            if (b === "HEAD") {
+                return Promise.resolve(abTable[a] ?? NaN);
+            } else if (a === "HEAD") {
+                return Promise.resolve(-(abTable[b] ?? NaN));
+            }
+
+            return Promise.resolve(NaN);
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
+    });
 });

--- a/test/fetchPrecedingTag.test.ts
+++ b/test/fetchPrecedingTag.test.ts
@@ -54,4 +54,146 @@ describe("fetchPrecedingTag", () => {
 
         expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
     });
+
+    test("should return the latest commit date of equal distance tags", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2"])
+        });
+
+        mockGithubAPI.fetchCommitDifference.mockResolvedValue(2);
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const committerCommitDate = ({
+                "tag1": "2025-09-10T03:37:12Z",
+                "tag2": "2025-09-09T06:23:06Z"
+            })[tag] ?? "1980-01-01T00:00:00Z";
+
+            return Promise.resolve({
+                committer: committerCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
+
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const committerCommitDate = ({
+                "tag1": "2025-09-09T06:23:06Z",
+                "tag2": "2025-09-10T03:37:12Z"
+            })[tag];
+
+            return Promise.resolve({
+                committer: committerCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
+
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const authorCommitDate = ({
+                "tag1": "2025-09-01T14:12:54Z",
+                "tag2": "2025-09-02T23:25:37Z"
+            })[tag];
+
+            return Promise.resolve({
+                author: authorCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
+
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const authorCommitDate = ({
+                "tag1": "2025-09-02T23:25:37Z",
+                "tag2": "2025-09-01T14:12:54Z"
+            })[tag];
+
+            return Promise.resolve({
+                author: authorCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
+
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const committerCommitDate = ({
+                "tag1": "2025-08-14T01:02:03Z",
+            })[tag];
+
+            return Promise.resolve({
+                committer: committerCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag1");
+
+        mockGithubAPI.fetchCommitDate.mockImplementation((tag) => {
+            const committerCommitDate = ({
+                "tag2": "2025-08-14T01:02:03Z",
+            })[tag];
+
+            return Promise.resolve({
+                committer: committerCommitDate
+            });
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag2");
+    });
+
+    test("should return something for basically equal tags", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2"])
+        });
+
+        mockGithubAPI.fetchCommitDifference.mockResolvedValue(3);
+        mockGithubAPI.fetchCommitDate.mockResolvedValue({});
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).not.toBeNull();
+    });
+
+    test("should not include tags pointing to this ref if includeRef is false", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
+        });
+
+        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
+            const abTable: Record<string, number> = {
+                "tag1": -1,
+                "tag2": 0,
+                "tag3": 1
+            };
+
+            if (b === "HEAD") {
+                return Promise.resolve(abTable[a] ?? NaN);
+            } else if (a === "HEAD") {
+                return Promise.resolve(-(abTable[b] ?? NaN));
+            }
+
+            return Promise.resolve(NaN);
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD")).toBe("tag3");
+    });
+
+    test("should include tags pointing to this ref if includeRef is true", async () => {
+        const mockGithubAPI = mock<GitHubAPI>({
+            fetchAllTags: () => Promise.resolve(["tag1", "tag2", "tag3"])
+        });
+
+        mockGithubAPI.fetchCommitDifference.mockImplementation((a, b) => {
+            const abTable: Record<string, number> = {
+                "tag1": -1,
+                "tag2": 0,
+                "tag3": 1
+            };
+
+            if (b === "HEAD") {
+                return Promise.resolve(abTable[a] ?? NaN);
+            } else if (a === "HEAD") {
+                return Promise.resolve(-(abTable[b] ?? NaN));
+            }
+
+            return Promise.resolve(NaN);
+        });
+
+        expect(await fetchPrecedingTag(mockGithubAPI, "HEAD", {includeRef: true})).toBe("tag2");
+    });
 });


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
This change adds a bunch of unit tests to `fetchPrecedingTag`.

## Why are these changes being made?
This is the primary logic of the program, and as such it should be well tested.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.