### PR TITLE
Disable fuzzing on critical refs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -157,6 +157,7 @@ jobs:
         key: npm-${{ runner.os }}-${{ hashFiles('./package-lock.json') }}
     
     - name: Run ${{ matrix.script }}
+      if: ${{ !(matrix.script == 'fuzz' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/release-'))) }}
       env:
         SCRIPT: ${{ matrix.script }}
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -446,6 +446,7 @@ jobs:
       uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
       with:
         body: ⚠️ This release is largely untested, use at your own risk. ⚠️
+        draft: true
         generateReleaseNotes: true
         immutableCreate: true
         makeLatest: ${{ steps.is-latest-release.outputs.is-latest == 'true' }}


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
This change disables running fuzz tests on main and on release tags. This change also marks future auto releases as drafts.

## Why are these changes being made?
CI should be deterministic and repeatable for the default branch and release workflows. I'd like to avoid flaky tests here where possible, especially if the flakiness is not network related.

As for the release change, I've been having an issue with the auto generated release notes and need to edit them for every auto release. Setting release to draft allows me to make those changes before publishing a release.

## Checklist before merging
- [ ] `./npm run check-types` succeeds.
- [ ] `./npm run lint` succeeds.
- [ ] `./npm run test` succeeds.
- [ ] `./npm run bundle` succeeds.
- [ ] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.