### PR TITLE
Update comment for listMatchingRefs

### DIFF
--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -18,7 +18,14 @@ class GitHubAPI {
      * Will reject if the API is unavailable.
      */
     async fetchAllTags(filter: RegExp): Promise<string[]> {
-        // https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references
+        /*
+         * https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references
+         * Yes, this endpoint looks like it lists every tag. See for yourself:
+         * https://api.github.com/repos/torvalds/linux/git/matching-refs/tags
+         *
+         * If for some reason this doesn't return every tag, switch to iterating over listTags:
+         * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
+         */
         return this.octokit.rest.git.listMatchingRefs({
             owner: this.repo.owner,
             repo: this.repo.repo,
@@ -34,11 +41,6 @@ class GitHubAPI {
                 })
                 .filter((tag: string) => filter.test(tag));
         });
-
-        /*
-         * If the above endpoint doesn't return all tags for some reason, switch to iterating over listTags
-         * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-         */
     }
 
     /**


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
Update `listMatchingRefs` comment.

## Why are these changes being made?
This should give developers ease of mind that no tags will be missing from the GitHub API. At the time of writing, `torvalds/linux` has 900 tags and the *list matching references* endpoint returns [every single one](https://api.github.com/repos/torvalds/linux/git/matching-refs/tags).

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.