### PR TITLE
Add input memoization, and add `getDefaultTag` implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "format": "eslint --fix",
         "fuzz": "vitest run --project fuzz",
         "lint": "eslint",
+        "pr-checks": "npm run check-types && npm run lint && npm run test && npm run bundle",
         "run-bundle": "node dist/index.js",
         "test": "vitest run --project unit"
     },

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -38,11 +38,7 @@ class Input {
         }
 
         const defaultTag = this.getInput("default-tag");
-        if (defaultTag.length === 0) {
-            return "";
-        }
-
-        if (!this.getFilter().test(defaultTag)) {
+        if (defaultTag.length !== 0 && !this.getFilter().test(defaultTag)) {
             this.warning(`Input default-tag "${defaultTag}" does not match the tag filter.`);
         }
 
@@ -60,10 +56,11 @@ class Input {
 
         const filterString = this.getInput("regex");
         if (filterString.length === 0) {
-            return /^.+$/;
+            this.memoization.getFilter = /^.+$/;
+        } else {
+            this.memoization.getFilter = new RegExp(filterString);
         }
 
-        this.memoization.getFilter = new RegExp(filterString);
         return this.memoization.getFilter;
     }
 
@@ -77,7 +74,6 @@ class Input {
 
         if (this.getInput("include-ref").length === 0) {
             this.memoization.getIncludeRef = false;
-            return this.memoization.getIncludeRef;
         } else {
             this.memoization.getIncludeRef = this.getBooleanInput("include-ref");
         }

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,49 +1,98 @@
-import type { getBooleanInput, getInput } from "@actions/core";
+import type { getBooleanInput, getInput, warning } from "@actions/core";
 import type { context } from "@actions/github";
 
 import type { Repository } from "./types/Repository";
 
 type Core_getBooleanInput = typeof getBooleanInput;
 type Core_getInput = typeof getInput;
+type Core_warning = typeof warning;
 type Github_context = typeof context;
+
+type MemoizationTable = {
+    [key in keyof Input]?: key extends `get${string}` ? ReturnType<Input[key]> : never
+}
 
 class Input {
     private readonly context: Github_context;
     private readonly getBooleanInput: Core_getBooleanInput;
     private readonly getInput: Core_getInput;
-    constructor(getInput: Core_getInput, getBooleanInput: Core_getBooleanInput, context: Github_context) {
+    private readonly warning: Core_warning;
+
+    private readonly memoization: MemoizationTable;
+
+    constructor(getInput: Core_getInput, getBooleanInput: Core_getBooleanInput, warning: Core_warning, context: Github_context) {
         this.context = context;
         this.getBooleanInput = getBooleanInput;
         this.getInput = getInput;
+        this.warning = warning;
+
+        this.memoization = {};
+    }
+
+    /**
+     * The default value to return if no preceding tag was found.
+     */
+    getDefaultTag(): string {
+        if (this.memoization.getDefaultTag != null) {
+            return this.memoization.getDefaultTag;
+        }
+
+        const defaultTag = this.getInput("default-tag");
+        if (defaultTag.length === 0) {
+            return "";
+        }
+
+        if (!this.getFilter().test(defaultTag)) {
+            this.warning(`Input default-tag "${defaultTag}" does not match the tag filter.`);
+        }
+
+        this.memoization.getDefaultTag = defaultTag;
+        return defaultTag;
     }
 
     /**
      * Get the tag filtering regular expression, defaults to matching every non-zero string.
      */
     getFilter(): RegExp {
+        if (this.memoization.getFilter != null) {
+            return this.memoization.getFilter;
+        }
+
         const filterString = this.getInput("regex");
         if (filterString.length === 0) {
             return /^.+$/;
         }
 
-        return new RegExp(filterString);
+        this.memoization.getFilter = new RegExp(filterString);
+        return this.memoization.getFilter;
     }
 
     /**
      * Return the include-ref option, defaults to false.
      */
     getIncludeRef(): boolean {
-        if (this.getInput("include-ref").length === 0) {
-            return false;
+        if (this.memoization.getIncludeRef != null) {
+            return this.memoization.getIncludeRef;
         }
 
-        return this.getBooleanInput("include-ref");
+        if (this.getInput("include-ref").length === 0) {
+            this.memoization.getIncludeRef = false;
+            return this.memoization.getIncludeRef;
+        } else {
+            this.memoization.getIncludeRef = this.getBooleanInput("include-ref");
+        }
+
+        return this.memoization.getIncludeRef;
     }
 
     /**
      * Get the ref to get the preceding tag of. Defaults to HEAD if not supplied for some reason.
      */
     getRef(): string {
+        if (this.memoization.getRef != null) {
+            return this.memoization.getRef;
+        }
+
         const startsWithRef = /^refs\//i;
         const invalidGitSequences = /(\.\/)|(\.\.)|(\.lock$)|[~^:?*[@\\]|(\/\/)|(\.$)/;
         const invalidURLSequences = /[?&/$%]|(^\.)|(\.$)/;
@@ -52,21 +101,28 @@ class Input {
             throw new SyntaxError(`Invalid input ref "${ref}"`);
         }
 
-        return ref.length > 0 ? ref : "HEAD";
+        this.memoization.getRef = ref.length > 0 ? ref : "HEAD";
+        return this.memoization.getRef;
     }
 
     /**
      * Generate a Repository object, either from the action inputs or the context this action is running in.
      */
     getRepository(): Repository {
+        if (this.memoization.getRepository != null) {
+            return this.memoization.getRepository;
+        }
+
         const validRepositoryString = /^[a-z\d-]+\/[\w.-]+$/i;
         const invalidRepositorySequences = /(\/\.)|(\/\.\.)/;
         const inputString = this.getInput("repository");
         if (inputString.length === 0) {
-            return {
+            this.memoization.getRepository = {
                 owner: this.context.repo.owner,
                 repo: this.context.repo.repo
             };
+
+            return this.memoization.getRepository;
         }
 
         const matcher = inputString.match(/^(?<owner>[^/]+)\/(?<repo>[^/]+)$/);
@@ -74,22 +130,30 @@ class Input {
             throw new SyntaxError(`Invalid input repository "${inputString}". Expected format {owner}/{repo}`);
         }
 
-        return {
+        this.memoization.getRepository = {
             owner: matcher.groups.owner,
             repo: matcher.groups.repo
         };
+
+        return this.memoization.getRepository;
     }
 
     /**
      * Return the token if it exists, or undefined.
      */
     getToken(): string | undefined {
-        const token = this.getInput("token");
-        if (token.length === 0) {
-            return undefined;
+        if ("getToken" in this.memoization) {
+            return this.memoization.getToken;
         }
 
-        return token;
+        const token = this.getInput("token");
+        if (token.length === 0) {
+            this.memoization.getToken = undefined;
+        } else {
+            this.memoization.getToken = token;
+        }
+
+        return this.memoization.getToken;
     }
 }
 

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -7,7 +7,7 @@ import { GitHubAPI } from "./GitHubAPI";
 import { Input } from "./Input";
 
 async function main(): Promise<void> {
-    const input: Input = new Input(core.getInput, core.getBooleanInput, context);
+    const input: Input = new Input(core.getInput, core.getBooleanInput, core.warning, context);
     const octokit: Octokit = new Octokit({
         auth: input.getToken()
     });

--- a/test/Input.test.ts
+++ b/test/Input.test.ts
@@ -35,7 +35,7 @@ describe("Input", () => {
         test("should return a non-zero match-all regular expression on an empty input", () => {
             const getInput = vi.fn().mockReturnValue("");
             const getBooleanInput = makeGetBooleanInput(getInput);
-            const input = new Input(getInput, getBooleanInput, mock<Github_context>({}));
+            const input = new Input(getInput, getBooleanInput, vi.fn(), mock<Github_context>({}));
             const regex = input.getFilter();
             expect(regex.test("")).toBe(false);
             expect(regex.test("a1-.")).toBe(true);
@@ -45,31 +45,31 @@ describe("Input", () => {
     describe("getRef", () => {
         test("should fail on .. input", () => {
             const getInput = vi.fn().mockReturnValue("..");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRef()).toThrowError(/^Invalid input ref /);
         });
 
         test("should fail on ./ input", () => {
             const getInput = vi.fn().mockReturnValue("./");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRef()).toThrowError(/^Invalid input ref /);
         });
 
         test("should fail on input beginning with .", () => {
             const getInput = vi.fn().mockReturnValue(".abc");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRef()).toThrowError(/^Invalid input ref /);
         });
 
         test("should fail on input ending with .", () => {
             const getInput = vi.fn().mockReturnValue("abc.");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRef()).toThrowError(/^Invalid input ref /);
         });
 
         test("should fail on input containing &", () => {
             const getInput = vi.fn().mockReturnValue("someref&foo");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRef()).toThrowError(/^Invalid input ref /);
         });
     });
@@ -77,7 +77,7 @@ describe("Input", () => {
     describe("getRepository", () => {
         test("should return owner and repo", () => {
             const getInput = vi.fn().mockReturnValue("AJGranowski/preceding-tag-action");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(input.getRepository()).toEqual({
                 owner: "AJGranowski",
                 repo: "preceding-tag-action"
@@ -86,7 +86,7 @@ describe("Input", () => {
 
         test("should not fail if repo name contains two ..", () => {
             const getInput = vi.fn().mockReturnValue("AJGranowski/some..repo");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(input.getRepository()).toEqual({
                 owner: "AJGranowski",
                 repo: "some..repo"
@@ -95,25 +95,25 @@ describe("Input", () => {
 
         test("should fail on repo name .", () => {
             const getInput = vi.fn().mockReturnValue("AJGranowski/.");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRepository()).toThrowError(/^Invalid input repository /);
         });
 
         test("should fail on repo name ..", () => {
             const getInput = vi.fn().mockReturnValue("AJGranowski/..");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRepository()).toThrowError(/^Invalid input repository /);
         });
 
         test("should fail if there is no /", () => {
             const getInput = vi.fn().mockReturnValue("AJGranowski");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRepository()).toThrowError(/^Invalid input repository /);
         });
 
         test("should fail if there is only /", () => {
             const getInput = vi.fn().mockReturnValue("/");
-            const input = new Input(getInput, vi.fn(), mock<Github_context>({}));
+            const input = new Input(getInput, vi.fn(), vi.fn(), mock<Github_context>({}));
             expect(() => input.getRepository()).toThrowError(/^Invalid input repository /);
         });
     });

--- a/test/PrecedingTagAction.test.ts
+++ b/test/PrecedingTagAction.test.ts
@@ -14,7 +14,8 @@ vi.mock("@actions/core", () => ({
     getInput: vi.fn(() => ""),
     getBooleanInput: vi.fn(() => false),
     setFailed: vi.fn(),
-    setOutput: vi.fn()
+    setOutput: vi.fn(),
+    warning: vi.fn()
 }));
 
 vi.mock("@actions/github", () => ({


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
* Add input memoization so checks on inputs are only run once instead of on each call.
* Add `getDefaultTag` as a part of #45. This is just a partial implementation and is not integrated with the rest of the program (nothing calls `getDefaultTag` yet).

## Why are these changes being made?
These changes are made to progressively address #45.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.