### PR TITLE
Add `default-tag` option

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,6 +109,14 @@ jobs:
             repository: ""
             expected-tag: "this-is-a-default-tag"
             expected-tag-found: false
+          - name: Should warn if the default-tag does not match the regex.
+            default-tag: "123"
+            include-ref: ""
+            ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
+            regex: "^[a-zA-Z]+$"
+            repository: ""
+            expected-tag: "123"
+            expected-tag-found: false
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,29 +70,45 @@ jobs:
       matrix:
         include:
           - name: Should return the preceding tag from a SHA.
+            default-tag: ""
             include-ref: ""
             ref: 7f6f9a02a5f985b460f60b8dbe6c11294695c96f
             regex: ""
             repository: ""
             expected-tag: release-0.0.0
+            expected-tag-found: true
           - name: Should return the preceding tag from a tag.
+            default-tag: ""
             include-ref: ""
             ref: release-0.0.2
             regex: ^release-.+$
             repository: ""
             expected-tag: release-0.0.1
+            expected-tag-found: true
           - name: Should return this tag if ref matches the filter and include-ref is set to true.
+            default-tag: ""
             include-ref: true
             ref: release-0.0.2
             regex: ^release-.+$
             repository: ""
             expected-tag: release-0.0.2
+            expected-tag-found: true
           - name: Should return an empty string if no preceding tag exists.
+            default-tag: ""
             include-ref: ""
             ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
             regex: ""
             repository: ""
             expected-tag: ""
+            expected-tag-found: false
+          - name: Should return the default-tag if no preceding tag exists.
+            default-tag: "this-is-a-default-tag"
+            include-ref: ""
+            ref: 42371bd608bcc9ca46e0a3be0e3403571cd8d824
+            regex: ""
+            repository: ""
+            expected-tag: "this-is-a-default-tag"
+            expected-tag-found: false
 
     steps:
     - name: Harden Runner
@@ -114,14 +130,22 @@ jobs:
       id: preceding-tag-local
       uses: ./
       with:
+        default-tag: ${{ matrix.default-tag }}
         include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
         regex: ${{ matrix.regex }}
         repository: ${{ matrix.repository }}
 
-    - name: Compare Output
+    - name: Compare Output (tag)
       env:
         EXPECTED_TAG: ${{ matrix.expected-tag }}
         OUTPUTS_TAG: ${{ steps.preceding-tag-local.outputs.tag }}
       run: |
         [ "$EXPECTED_TAG" = "$OUTPUTS_TAG" ]
+
+    - name: Compare Output (tag-found)
+      env:
+        EXPECTED_TAG_FOUND: ${{ matrix.expected-tag-found }}
+        OUTPUTS_TAG_FOUND: ${{ steps.preceding-tag-local.outputs.tag-found }}
+      run: |
+        [ "$EXPECTED_TAG_FOUND" = "$OUTPUTS_TAG_FOUND" ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Although this project publishes version tags, I strongly recommend [pinning this
 | `repository`  | String  | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
 | `ref`         | String  | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
 | `regex`       | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
-| `default-tag` | String  | ``                         | The default tag to return if no preceding tag was found.                    |
+| `default-tag` | String  | `​`                         | The default tag to return if no preceding tag was found.                    |
 | `include-ref` | Boolean | `false`                    | If true, include tags pointing to `ref` as candidates.                      |
 | `token`       | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ Although this project publishes version tags, I strongly recommend [pinning this
 | `repository`  | String  | `${{ github.repository }}` | Repository name with owner. For example, `AJGranowski/preceding-tag-action` |
 | `ref`         | String  | `${{ github.sha }}`        | The branch, tag, or SHA to find the preceding tag from.                     |
 | `regex`       | String  | `^.+$`                     | A regular expression used to filter candidate tag names.                    |
+| `default-tag` | String  | ``                         | The default tag to return if no preceding tag was found.                    |
 | `include-ref` | Boolean | `false`                    | If true, include tags pointing to `ref` as candidates.                      |
 | `token`       | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                         |
 
 ## Outputs
-| Name  | Type   | Description  |
-|-------|--------|------------------------------------------------------------------------------------------|
-| `tag` | String | The preceding tag, or an empty string if no preceding tag matching the filter was found. |
+| Name        | Type    | Description                                                                            |
+|-------------|---------|----------------------------------------------------------------------------------------|
+| `tag`       | String  | The preceding tag, or `default-tag` if no preceding tag matching the filter was found. |
+| `tag-found` | Boolean | True if the preceding tag was found. False if the `default-tag` fallback was used.     |
 
 [cicd-badge]: https://github.com/AJGranowski/preceding-tag-action/actions/workflows/cicd.yml/badge.svg?branch=main
 [cicd-link]: https://github.com/AJGranowski/preceding-tag-action/actions/workflows/cicd.yml

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ runs:
   main: dist/index.js
 
 inputs:
+  default-tag:
+    description: The default tag to return if no preceding tag was found.
+    default: ""
+    required: false
   include-ref:
     description: If true, include tags pointing to `ref` as candidates.
     default: "false"
@@ -33,4 +37,6 @@ inputs:
 
 outputs:
   tag:
-    description: The preceding tag, or an empty string if no preceding tag matching the filter was found.
+    description: The preceding tag, or `default-tag` if no preceding tag matching the filter was found.
+  tag-found:
+    description: True if the preceding tag was found. False if the `default-tag` fallback was used.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: AJ Granowski
 description: Find the most recent tag that is reachable from a commit.
 branding:
   color: orange
-  icon: git-merge
+  icon: tag
 
 runs:
   using: node24

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -30,6 +30,18 @@ class Input {
     }
 
     /**
+     * Validate each input.
+     */
+    validateInputs(): void {
+        this.getDefaultTag();
+        this.getFilter();
+        this.getIncludeRef();
+        this.getRef();
+        this.getRepository();
+        this.getToken();
+    }
+
+    /**
      * The default value to return if no preceding tag was found.
      */
     getDefaultTag(): string {

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -8,6 +8,7 @@ import { Input } from "./Input";
 
 async function main(): Promise<void> {
     const input: Input = new Input(core.getInput, core.getBooleanInput, core.warning, context);
+    input.validateInputs();
     const octokit: Octokit = new Octokit({
         auth: input.getToken()
     });
@@ -19,7 +20,7 @@ async function main(): Promise<void> {
     });
 
     if (precedingTag == null) {
-        core.setOutput("tag", "");
+        core.setOutput("tag", input.getDefaultTag());
     } else {
         core.setOutput("tag", precedingTag);
     }

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -21,8 +21,10 @@ async function main(): Promise<void> {
 
     if (precedingTag == null) {
         core.setOutput("tag", input.getDefaultTag());
+        core.setOutput("tag-found", false);
     } else {
         core.setOutput("tag", precedingTag);
+        core.setOutput("tag-found", true);
     }
 }
 

--- a/test/GitHubAPI.test.ts
+++ b/test/GitHubAPI.test.ts
@@ -87,7 +87,7 @@ describe("GitHubAPI", () => {
             });
 
             const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            expect(githubAPI.fetchAllTags(new RegExp(""))).rejects.toThrowError();
+            await expect(githubAPI.fetchAllTags(new RegExp(""))).rejects.toThrowError();
         });
     });
 
@@ -195,7 +195,7 @@ describe("GitHubAPI", () => {
             });
 
             const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
+            await expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
         });
 
         test("should throw error if behind_by is negative", async () => {
@@ -215,7 +215,7 @@ describe("GitHubAPI", () => {
             });
 
             const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
+            await expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
         });
 
         test("should throw error on unknown status", async () => {
@@ -232,7 +232,7 @@ describe("GitHubAPI", () => {
             });
 
             const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
+            await expect(githubAPI.fetchCommitDifference("ref1", "ref2")).rejects.toThrowError();
         });
     });
 });

--- a/test/PrecedingTagAction.fuzz.test.ts
+++ b/test/PrecedingTagAction.fuzz.test.ts
@@ -157,7 +157,7 @@ describe("Fuzzing PrecedingTagAction", () => {
                 expect(core.setOutput).not.toBeCalled();
             } else {
                 expect(core.setFailed).not.toBeCalled();
-                expect(core.setOutput).toHaveBeenCalledOnce();
+                expect(core.setOutput).toBeCalledTimes(2);
             }
         };
 


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
This change adds the new input `default-tag`, and the new output `tag-found`. This change will not affect existing configurations, as the default behavior will still be returning an empty string if the preceding tag was not found.

## Why are these changes being made?
This change resolves #45 by adding a fallback option.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.