### PR TITLE
Add support for large repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "dependencies": {
                 "@actions/core": "^1.11.1",
                 "@actions/github": "^6.0.1",
+                "@octokit/plugin-retry": "^8.0.1",
+                "@octokit/plugin-throttling": "^11.0.1",
                 "@octokit/rest": "^22.0.0"
             },
             "devDependencies": {
@@ -56,6 +58,107 @@
                 "@octokit/request-error": "^5.1.1",
                 "undici": "^5.28.5"
             }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/core": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/graphql": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "license": "MIT"
+        },
+        "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@actions/github/node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@actions/http-client": {
             "version": "2.2.3",
@@ -911,31 +1014,93 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
             "license": "MIT",
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-            "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
+            "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.1.0",
-                "@octokit/request": "^8.4.1",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.1",
+                "@octokit/request": "^10.0.2",
+                "@octokit/request-error": "^7.0.0",
+                "@octokit/types": "^14.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
+        },
+        "node_modules/@octokit/core/node_modules/@octokit/endpoint": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+            "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^14.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+            "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/core/node_modules/@octokit/request": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+            "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.0",
+                "@octokit/request-error": "^7.0.0",
+                "@octokit/types": "^14.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core/node_modules/@octokit/request-error": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+            "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^14.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core/node_modules/@octokit/types": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+            "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^25.1.0"
+            }
+        },
+        "node_modules/@octokit/core/node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "license": "ISC"
         },
         "node_modules/@octokit/endpoint": {
             "version": "9.0.6",
@@ -951,18 +1116,80 @@
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+            "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^8.4.1",
-                "@octokit/types": "^13.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^10.0.2",
+                "@octokit/types": "^14.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
+        },
+        "node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+            "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^14.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+            "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/graphql/node_modules/@octokit/request": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+            "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/endpoint": "^11.0.0",
+                "@octokit/request-error": "^7.0.0",
+                "@octokit/types": "^14.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "universal-user-agent": "^7.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql/node_modules/@octokit/request-error": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+            "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^14.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+            "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^25.1.0"
+            }
+        },
+        "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "license": "ISC"
         },
         "node_modules/@octokit/openapi-types": {
             "version": "24.2.0",
@@ -970,64 +1197,79 @@
             "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
             "license": "MIT"
         },
-        "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-            "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+        "node_modules/@octokit/plugin-retry": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
+            "integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^12.6.0"
+                "@octokit/request-error": "^7.0.0",
+                "@octokit/types": "^14.0.0",
+                "bottleneck": "^2.15.3"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "5"
+                "@octokit/core": ">=7"
             }
         },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+        "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+            "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
             "license": "MIT"
         },
-        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+        "node_modules/@octokit/plugin-retry/node_modules/@octokit/request-error": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+            "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^12.6.0"
+                "@octokit/types": "^14.0.0"
             },
             "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "@octokit/core": "5"
+                "node": ">= 20"
             }
         },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-            "license": "MIT"
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-            "version": "12.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+        "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+            "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
             "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^20.0.0"
+                "@octokit/openapi-types": "^25.1.0"
+            }
+        },
+        "node_modules/@octokit/plugin-throttling": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
+            "integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^14.0.0",
+                "bottleneck": "^2.15.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": "^7.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+            "version": "25.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+            "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+            "license": "MIT"
+        },
+        "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+            "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/openapi-types": "^25.1.0"
             }
         },
         "node_modules/@octokit/request": {
@@ -1069,60 +1311,6 @@
                 "@octokit/plugin-paginate-rest": "^13.0.1",
                 "@octokit/plugin-request-log": "^6.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "^16.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@octokit/rest/node_modules/@octokit/core": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
-            "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/auth-token": "^6.0.0",
-                "@octokit/graphql": "^9.0.1",
-                "@octokit/request": "^10.0.2",
-                "@octokit/request-error": "^7.0.0",
-                "@octokit/types": "^14.0.0",
-                "before-after-hook": "^4.0.0",
-                "universal-user-agent": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
-            "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^14.0.0",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
-            "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/request": "^10.0.2",
-                "@octokit/types": "^14.0.0",
-                "universal-user-agent": "^7.0.0"
             },
             "engines": {
                 "node": ">= 20"
@@ -1176,34 +1364,6 @@
                 "@octokit/core": ">=6"
             }
         },
-        "node_modules/@octokit/rest/node_modules/@octokit/request": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
-            "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/endpoint": "^11.0.0",
-                "@octokit/request-error": "^7.0.0",
-                "@octokit/types": "^14.0.0",
-                "fast-content-type-parse": "^3.0.0",
-                "universal-user-agent": "^7.0.2"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
-            "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
-            "license": "MIT",
-            "dependencies": {
-                "@octokit/types": "^14.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/@octokit/rest/node_modules/@octokit/types": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
@@ -1212,18 +1372,6 @@
             "dependencies": {
                 "@octokit/openapi-types": "^25.1.0"
             }
-        },
-        "node_modules/@octokit/rest/node_modules/before-after-hook": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@octokit/rest/node_modules/universal-user-agent": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-            "license": "ISC"
         },
         "node_modules/@octokit/types": {
             "version": "13.10.0",
@@ -2079,10 +2227,16 @@
             "license": "MIT"
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
             "license": "Apache-2.0"
+        },
+        "node_modules/bottleneck": {
+            "version": "2.19.5",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.1",
+        "@octokit/plugin-retry": "^8.0.1",
+        "@octokit/plugin-throttling": "^11.0.1",
         "@octokit/rest": "^22.0.0"
     },
     "devDependencies": {

--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -20,7 +20,7 @@ class GitHubAPI {
      */
     async fetchAllTags(filter: RegExp): Promise<string[]> {
         // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-        const response = await this.octokit.paginate(this.octokit.repos.listTags, {
+        const response = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
             owner: this.repo.owner,
             repo: this.repo.repo,
             per_page: 100 // max

--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -7,6 +7,7 @@ import type { Repository } from "./types/Repository";
 class GitHubAPI {
     private readonly octokit: Octokit;
     private readonly repo: Repository;
+
     constructor(octokit: Octokit, repo: Repository) {
         this.octokit = octokit;
         this.repo = repo;
@@ -18,29 +19,15 @@ class GitHubAPI {
      * Will reject if the API is unavailable.
      */
     async fetchAllTags(filter: RegExp): Promise<string[]> {
-        /*
-         * https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references
-         * Yes, this endpoint looks like it lists every tag. See for yourself:
-         * https://api.github.com/repos/torvalds/linux/git/matching-refs/tags
-         *
-         * If for some reason this doesn't return every tag, switch to iterating over listTags:
-         * https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-         */
-        return this.octokit.rest.git.listMatchingRefs({
+        // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
+        const response = await this.octokit.paginate(this.octokit.repos.listTags, {
             owner: this.repo.owner,
             repo: this.repo.repo,
-            ref: "tags"
-        }).then((response) => {
-            return response.data
-                .map((object) => {
-                    if (!object.ref.startsWith("refs/tags/")) {
-                        throw new Error(`Returned ref is not a tag: ${object.ref}`);
-                    }
-
-                    return object.ref.substring("refs/tags/".length);
-                })
-                .filter((tag: string) => filter.test(tag));
+            per_page: 100 // max
         });
+
+        return response.map((object) => object.name)
+            .filter((tag: string) => filter.test(tag));
     }
 
     /**
@@ -54,34 +41,34 @@ class GitHubAPI {
      */
     async fetchCommitDifference(base: GitRef, head: GitRef): Promise<number> {
         // https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits
-        return this.octokit.rest.repos.compareCommitsWithBasehead({
+        const response = await this.octokit.rest.repos.compareCommitsWithBasehead({
             owner: this.repo.owner,
             repo: this.repo.repo,
             basehead: `${base}...${head}`,
             page: 1,
             per_page: 1
-        }).then((response) => {
-            switch (response.data.status) {
-                case "ahead":
-                    if (response.data.ahead_by < 0) {
-                        throw new Error(`ahead_by property is negative: ${response.data.ahead_by}`);
-                    }
-
-                    return response.data.ahead_by;
-                case "behind":
-                    if (response.data.behind_by < 0) {
-                        throw new Error(`behind_by property is negative: ${response.data.behind_by}`);
-                    }
-
-                    return -response.data.behind_by;
-                case "identical":
-                    return 0;
-                case "diverged":
-                    return NaN;
-                default:
-                    throw new Error(`Unknown compare status: ${response.data.status}`);
-            }
         });
+
+        switch (response.data.status) {
+            case "ahead":
+                if (response.data.ahead_by < 0) {
+                    throw new Error(`ahead_by property is negative: ${response.data.ahead_by}`);
+                }
+
+                return response.data.ahead_by;
+            case "behind":
+                if (response.data.behind_by < 0) {
+                    throw new Error(`behind_by property is negative: ${response.data.behind_by}`);
+                }
+
+                return -response.data.behind_by;
+            case "identical":
+                return 0;
+            case "diverged":
+                return NaN;
+            default:
+                throw new Error(`Unknown compare status: ${response.data.status}`);
+        }
     }
 
     /**
@@ -91,18 +78,18 @@ class GitHubAPI {
      */
     async fetchCommitDate(ref: GitRef): Promise<CommitDate> {
         // https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit
-        return this.octokit.rest.repos.getCommit({
+        const response = await this.octokit.rest.repos.getCommit({
             owner: this.repo.owner,
             repo: this.repo.repo,
             ref: ref,
             page: 1,
             per_page: 1
-        }).then((response) => {
-            return {
-                author: response.data.commit.author?.date,
-                committer: response.data.commit.committer?.date
-            };
         });
+
+        return {
+            author: response.data.commit.author?.date,
+            committer: response.data.commit.committer?.date
+        };
     }
 }
 

--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -20,13 +20,13 @@ class GitHubAPI {
      */
     async fetchAllTags(filter: RegExp): Promise<string[]> {
         // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-        const response = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
+        const data = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
             owner: this.repo.owner,
             repo: this.repo.repo,
             per_page: 100 // max
         });
 
-        return response.map((object) => object.name)
+        return data.map((object) => object.name)
             .filter((tag: string) => filter.test(tag));
     }
 

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -1,16 +1,44 @@
 import * as core from "@actions/core";
 import { context } from "@actions/github";
 import { Octokit } from "@octokit/rest";
+import { retry } from "@octokit/plugin-retry";
+import { throttling } from "@octokit/plugin-throttling";
 
 import { fetchPrecedingTag } from "./fetchPrecedingTag";
 import { GitHubAPI } from "./GitHubAPI";
 import { Input } from "./Input";
 
+// Do not retry if the retry time is longer than 62 minutes.
+const maxRetryTimeSeconds = 62 * 60;
+
 async function main(): Promise<void> {
     const input: Input = new Input(core.getInput, core.getBooleanInput, core.warning, context);
     input.validateInputs();
-    const octokit: Octokit = new Octokit({
-        auth: input.getToken()
+    const octokit: Octokit = new (Octokit.plugin(retry, throttling))({
+        auth: input.getToken() != null ? `token ${input.getToken()}` : undefined,
+        throttle: {
+            onRateLimit: (retryAfter, options, octokit, retryCount): boolean => {
+                const logPrefix = `Request quota exhausted for request ${options.method} ${JSON.stringify(options)}.`;
+                if (retryCount >= 1) {
+                    octokit.log.warn(logPrefix);
+                    return false;
+                }
+
+                if (retryAfter > maxRetryTimeSeconds) {
+                    octokit.log.warn(`${logPrefix} Retry time ${retryAfter} exceeds the maximum retry time (${maxRetryTimeSeconds}).`);
+                    return false;
+                }
+
+                const date = new Date();
+                date.setSeconds(date.getSeconds() + retryAfter);
+                octokit.log.warn(`${logPrefix} Retrying after ${retryAfter} seconds (${date.toISOString()})... `);
+                return true;
+            },
+            onSecondaryRateLimit: (retryAfter, options): boolean => {
+                octokit.log.error(`Abuse detected for request ${options.method} ${options.url}`);
+                return false;
+            }
+        }
     });
 
     const githubAPI = new GitHubAPI(octokit, input.getRepository());

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
                 }
 
                 if (retryAfter > maxRetryTimeSeconds) {
-                    octokit.log.warn(`${logPrefix} Retry time ${retryAfter} exceeds the maximum retry time (${maxRetryTimeSeconds}).`);
+                    octokit.log.warn(`${logPrefix} Retry time (${retryAfter} seconds) exceeds the maximum retry time (${maxRetryTimeSeconds} seconds).`);
                     return false;
                 }
 

--- a/test/GitHubAPI.test.ts
+++ b/test/GitHubAPI.test.ts
@@ -53,14 +53,15 @@ describe("GitHubAPI", () => {
             const expectedTags = ["tag1", "tag2", "tag3"];
             const response = {
                 data: expectedTags.map((tag) => ({
-                    ref: `refs/tags/${tag}`
+                    name: tag
                 }))
             };
 
             const octokit = mock<Octokit>({
+                paginate: (async (x: any, ...args: any) => (await x(...args)).data) as any,
                 rest: {
-                    git: {
-                        listMatchingRefs: (() => Promise.resolve(response)) as any
+                    repos: {
+                        listTags: (() => Promise.resolve(response)) as any
                     }
                 }
             });
@@ -69,25 +70,6 @@ describe("GitHubAPI", () => {
             const tags = await githubAPI.fetchAllTags(new RegExp(""));
             expect(tags).containSubset(expectedTags);
             expect(expectedTags).containSubset(tags);
-        });
-
-        test("should fail if the returned ref is not a tag", async () => {
-            const response = {
-                data: [{
-                    ref: "refs/heads/some-branch"
-                }]
-            };
-
-            const octokit = mock<Octokit>({
-                rest: {
-                    git: {
-                        listMatchingRefs: (() => Promise.resolve(response)) as any
-                    }
-                }
-            });
-
-            const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            await expect(githubAPI.fetchAllTags(new RegExp(""))).rejects.toThrowError();
         });
     });
 

--- a/test/PrecedingTagAction.test.ts
+++ b/test/PrecedingTagAction.test.ts
@@ -29,13 +29,13 @@ vi.mock("@actions/github", () => ({
 
 vi.mock("@octokit/rest", () => {
     const Octokit = vi.fn();
+    (Octokit as any).plugin = vi.fn().mockReturnValue(Octokit);
+    Octokit.prototype.paginate = async (x: any, ...args: any) => (await x(...args)).data;
     Octokit.prototype.rest = {
-        git: {
-            listMatchingRefs: vi.fn(() => Promise.reject())
-        },
         repos: {
             compareCommitsWithBasehead: vi.fn(() => Promise.reject()),
-            getCommit: vi.fn(() => Promise.reject())
+            getCommit: vi.fn(() => Promise.reject()),
+            listTags: vi.fn(() => Promise.reject())
         }
     };
 
@@ -44,7 +44,7 @@ vi.mock("@octokit/rest", () => {
 
 describe("PrecedingTagAction", () => {
     test("should fail with an unknown error if a promise rejects without an error", async () => {
-        (Octokit.prototype as Octokit).rest.git.listMatchingRefs = vi.fn(() => Promise.reject()) as any;
+        (Octokit.prototype as Octokit).rest.repos.listTags = vi.fn(() => Promise.reject()) as any;
         await PrecedingTagAction();
         expect(core.setFailed).toHaveBeenCalledExactlyOnceWith("An unknown error occurred.");
     });


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
* Migrate from `listMatchingRefs` to `listTags`.
* Add `retry` and `throttling` plugins.
* Use `await` instead of `.then` in `GitHubAPI`.

## Why are these changes being made?
This change resolves #49 by collecting tags from several smaller requests instead of one big request, and also by adding retry and throttling controls.

This change also closes #36 since there is no way to filter the tags requested from the `listTags` endpoint.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.