### PR TITLE
Increase fetch resilience

### DIFF
--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -4,6 +4,8 @@ import type { CommitDate } from "./types/CommitDate";
 import type { GitRef } from "./types/GitRef";
 import type { Repository } from "./types/Repository";
 
+const MAX_TAGS: number = 1000;
+
 class GitHubAPI {
     private readonly octokit: Octokit;
     private readonly repo: Repository;
@@ -19,15 +21,27 @@ class GitHubAPI {
      * Will reject if the API is unavailable.
      */
     async fetchAllTags(filter: RegExp): Promise<string[]> {
+        let totalTags = 0;
         // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-        const data = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
+        const allTags = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
             owner: this.repo.owner,
             repo: this.repo.repo,
             per_page: 100 // max
+        }, (response, done) => {
+            const result = response.data.filter((object) => object.commit.sha.length > 0 && filter.test(object.name))
+                .map((object) => object.name);
+
+            totalTags += result.length;
+            if (totalTags >= MAX_TAGS) {
+                this.octokit.log.warn(`Total tag limit reached in request ${response.url}. (${totalTags} >= ${MAX_TAGS})`);
+                done();
+            }
+
+            return result;
         });
 
-        return data.map((object) => object.name)
-            .filter((tag: string) => filter.test(tag));
+        this.octokit.log.debug(`${allTags.length} tags fetched.`);
+        return allTags;
     }
 
     /**
@@ -40,35 +54,27 @@ class GitHubAPI {
      * Will reject if the API is unavailable, or if the two references cannot be compared.
      */
     async fetchCommitDifference(base: GitRef, head: GitRef): Promise<number> {
-        // https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits
-        const response = await this.octokit.rest.repos.compareCommitsWithBasehead({
-            owner: this.repo.owner,
-            repo: this.repo.repo,
-            basehead: `${base}...${head}`,
-            page: 1,
-            per_page: 1
-        });
-
-        switch (response.data.status) {
-            case "ahead":
-                if (response.data.ahead_by < 0) {
-                    throw new Error(`ahead_by property is negative: ${response.data.ahead_by}`);
-                }
-
-                return response.data.ahead_by;
-            case "behind":
-                if (response.data.behind_by < 0) {
-                    throw new Error(`behind_by property is negative: ${response.data.behind_by}`);
-                }
-
-                return -response.data.behind_by;
-            case "identical":
-                return 0;
-            case "diverged":
+        let response;
+        try {
+            // https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits
+            response = await this.octokit.rest.repos.compareCommitsWithBasehead({
+                owner: this.repo.owner,
+                repo: this.repo.repo,
+                basehead: `${base}...${head}`,
+                page: 999_999_999_999, // The list of changed files is only shown on the first page of results.
+                per_page: 1
+            });
+        } catch (e: any) {
+            // GitHub will return a 422 error if the diff takes too long to generate.
+            if (this.isCompareDiffTooLargeError(e)) {
+                this.octokit.log.warn(`Diff too large for request ${e.request.method} ${e.request.url}. Defaulting difference to NaN.`);
                 return NaN;
-            default:
-                throw new Error(`Unknown compare status: ${response.data.status}`);
+            }
+
+            throw e;
         }
+
+        return this.parseCommitDifference(response);
     }
 
     /**
@@ -90,6 +96,47 @@ class GitHubAPI {
             author: response.data.commit.author?.date,
             committer: response.data.commit.committer?.date
         };
+    }
+
+    /**
+     * Return true if this error response is due to the compare diff taking too long to generate.
+     */
+    isCompareDiffTooLargeError(error: any): boolean {
+        if (error == null || error.status == null || error.request == null || error.response == null || error.response.data == null) {
+            return false;
+        }
+
+        if (error.status === 422 && error.response.data.message === "Server Error: Sorry, this diff is taking too long to generate.") {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Extract the commit difference from a compareCommitsWithBasehead response.
+     */
+    parseCommitDifference(response: Awaited<ReturnType<Octokit["rest"]["repos"]["compareCommitsWithBasehead"]>>): number {
+        switch (response.data.status) {
+            case "ahead":
+                if (response.data.ahead_by < 0) {
+                    throw new Error(`ahead_by property is negative: ${response.data.ahead_by}`);
+                }
+
+                return response.data.ahead_by;
+            case "behind":
+                if (response.data.behind_by < 0) {
+                    throw new Error(`behind_by property is negative: ${response.data.behind_by}`);
+                }
+
+                return -response.data.behind_by;
+            case "identical":
+                return 0;
+            case "diverged":
+                return NaN;
+            default:
+                throw new Error(`Unknown compare status: ${response.data.status}`);
+        }
     }
 }
 

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -24,6 +24,7 @@ async function main(): Promise<void> {
                     return false;
                 }
 
+                retryAfter = retryAfter + 10;
                 if (retryAfter > maxRetryTimeSeconds) {
                     octokit.log.warn(`${logPrefix} Retry time (${retryAfter} seconds) exceeds the maximum retry time (${maxRetryTimeSeconds} seconds).`);
                     return false;

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
         auth: input.getToken() != null ? `token ${input.getToken()}` : undefined,
         throttle: {
             onRateLimit: (retryAfter, options, octokit, retryCount): boolean => {
-                const logPrefix = `Request quota exhausted for request ${options.method} ${JSON.stringify(options)}.`;
+                const logPrefix = `Request quota exhausted for request ${options.method} ${options.url}.`;
                 if (retryCount >= 1) {
                     octokit.log.warn(logPrefix);
                     return false;
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
 
                 const date = new Date();
                 date.setSeconds(date.getSeconds() + retryAfter);
-                octokit.log.warn(`${logPrefix} Retrying after ${retryAfter} seconds (${date.toISOString()})... `);
+                console.log(`${logPrefix} Retrying after ${retryAfter} seconds (${date.toISOString()})... `);
                 return true;
             },
             onSecondaryRateLimit: (retryAfter, options): boolean => {

--- a/test/GitHubAPI.test.ts
+++ b/test/GitHubAPI.test.ts
@@ -53,12 +53,22 @@ describe("GitHubAPI", () => {
             const expectedTags = ["tag1", "tag2", "tag3"];
             const response = {
                 data: expectedTags.map((tag) => ({
-                    name: tag
+                    name: tag,
+                    commit: {
+                        sha: randomString()
+                    }
                 }))
             };
 
+            const paginate = async (fn: any, args: any, mapper: any = (response: any) => response.data) => {
+                return mapper(await fn(args), () => {});
+            };
+
             const octokit = mock<Octokit>({
-                paginate: (async (x: any, ...args: any) => (await x(...args)).data) as any,
+                log: {
+                    debug: () => {}
+                },
+                paginate: paginate as any,
                 rest: {
                     repos: {
                         listTags: (() => Promise.resolve(response)) as any

--- a/test/PrecedingTagAction.test.ts
+++ b/test/PrecedingTagAction.test.ts
@@ -30,7 +30,17 @@ vi.mock("@actions/github", () => ({
 vi.mock("@octokit/rest", () => {
     const Octokit = vi.fn();
     (Octokit as any).plugin = vi.fn().mockReturnValue(Octokit);
-    Octokit.prototype.paginate = async (x: any, ...args: any) => (await x(...args)).data;
+    Octokit.prototype.log = {
+        debug: () => {},
+        error: () => {},
+        info: () => {},
+        warn: () => {}
+    };
+
+    Octokit.prototype.paginate = async (fn: any, args: any, mapper: any = (response: any) => response.data) => {
+        return mapper(await fn(args), () => {});
+    };
+
     Octokit.prototype.rest = {
         repos: {
             compareCommitsWithBasehead: vi.fn(() => Promise.reject()),


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
* Limit the total number of tags to compare to 1000 (this is after applying the filter).
* Return NaN instead of failing if generating a comparison takes too long (422 error).

## Why are these changes being made?
<!-- Justify your proposed changes. -->

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.