### PR TITLE
Generalze the output of `getFilter`

### DIFF
--- a/src/GitHubAPI.ts
+++ b/src/GitHubAPI.ts
@@ -20,7 +20,7 @@ class GitHubAPI {
      *
      * Will reject if the API is unavailable.
      */
-    async fetchAllTags(filter: RegExp): Promise<string[]> {
+    async fetchAllTags(filter: (string: string) => boolean): Promise<string[]> {
         let totalTags = 0;
         // https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
         const allTags = await this.octokit.paginate(this.octokit.rest.repos.listTags, {
@@ -28,7 +28,7 @@ class GitHubAPI {
             repo: this.repo.repo,
             per_page: 100 // max
         }, (response, done) => {
-            const result = response.data.filter((object) => object.commit.sha.length > 0 && filter.test(object.name))
+            const result = response.data.filter((object) => object.commit.sha.length > 0 && filter(object.name))
                 .map((object) => object.name);
 
             totalTags += result.length;

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -50,7 +50,7 @@ class Input {
         }
 
         const defaultTag = this.getInput("default-tag");
-        if (defaultTag.length !== 0 && !this.getFilter().test(defaultTag)) {
+        if (defaultTag.length !== 0 && !this.getFilter()(defaultTag)) {
             this.warning(`Input default-tag "${defaultTag}" does not match the tag filter.`);
         }
 
@@ -61,16 +61,17 @@ class Input {
     /**
      * Get the tag filtering regular expression, defaults to matching every non-zero string.
      */
-    getFilter(): RegExp {
+    getFilter(): (string: string) => boolean {
         if (this.memoization.getFilter != null) {
             return this.memoization.getFilter;
         }
 
         const filterString = this.getInput("regex");
         if (filterString.length === 0) {
-            this.memoization.getFilter = /^.+$/;
+            this.memoization.getFilter = (string: string): boolean => string.length > 0;
         } else {
-            this.memoization.getFilter = new RegExp(filterString);
+            const regex = new RegExp(filterString);
+            this.memoization.getFilter = regex.test.bind(regex);
         }
 
         return this.memoization.getFilter;

--- a/src/fetchPrecedingTag.ts
+++ b/src/fetchPrecedingTag.ts
@@ -2,7 +2,7 @@ import type { GitHubAPI } from "./GitHubAPI";
 import type { GitRef } from "./types/GitRef";
 
 interface Options {
-    filter?: RegExp;
+    filter?: (string: string) => boolean;
     includeRef?: boolean;
 }
 
@@ -21,7 +21,7 @@ interface TagDifference {
  */
 async function fetchPrecedingTag(githubAPI: GitHubAPI, head: GitRef, options?: Options): Promise<string | null> {
     const optionsWithDefaults = {
-        filter: /^.+$/,
+        filter: (string: string): boolean => string.length > 0,
         includeRef: false,
         ...options
     } satisfies Required<Options>;

--- a/test/GitHubAPI.test.ts
+++ b/test/GitHubAPI.test.ts
@@ -77,7 +77,7 @@ describe("GitHubAPI", () => {
             });
 
             const githubAPI = new GitHubAPI(octokit, defaultRepo);
-            const tags = await githubAPI.fetchAllTags(new RegExp(""));
+            const tags = await githubAPI.fetchAllTags(() => true);
             expect(tags).containSubset(expectedTags);
             expect(expectedTags).containSubset(tags);
         });

--- a/test/Input.test.ts
+++ b/test/Input.test.ts
@@ -60,9 +60,9 @@ describe("Input", () => {
             const getInput = vi.fn().mockReturnValue("");
             const getBooleanInput = makeGetBooleanInput(getInput);
             const input = new Input(getInput, getBooleanInput, vi.fn(), mock<Github_context>({}));
-            const regex = input.getFilter();
-            expect(regex.test("")).toBe(false);
-            expect(regex.test("a1-.")).toBe(true);
+            const filter = input.getFilter();
+            expect(filter("")).toBe(false);
+            expect(filter("a1-.")).toBe(true);
         });
     });
 

--- a/test/PrecedingTagAction.fuzz.test.ts
+++ b/test/PrecedingTagAction.fuzz.test.ts
@@ -76,7 +76,7 @@ describe("Fuzzing PrecedingTagAction", () => {
                 status: fc.constant(200),
                 url: fc.webUrl(),
                 data: fc.array(fc.record({
-                    tag: fc.string(),
+                    name: fc.string(),
                     commit: fc.record({
                         sha: fc.string()
                     })


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
This change generalizes the output of `getFilter` from a regular expression, to a boolean function.

## Why are these changes being made?
Every usage of the regular expression was just using the `test` function, so why not just return that instead?

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.