### PR TITLE
Reduce CI runs from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,28 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "docker"
     directory: "/container-images/node/"
-    labels: []
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "infrastructure"
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels: []
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "infrastructure"
   - package-ecosystem: "npm"
     directory: "/"
     groups:
       eslint:
         patterns:
-          - "@eslint/js"
           - "eslint"
-    labels: []
-    open-pull-requests-limit: 10
+          - "@eslint/*"
+          - "*-eslint"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,20 +11,30 @@ multi-ecosystem-groups:
       interval: "weekly"
 
 updates:
-  - package-ecosystem: "docker"
-    directory: "/container-images/node/"
-    multi-ecosystem-group: "infrastructure"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    multi-ecosystem-group: "infrastructure"
-  - package-ecosystem: "npm"
-    directory: "/"
-    groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "@eslint/*"
-          - "*-eslint"
+- package-ecosystem: "docker"
+  directory: "/container-images/node/"
+  multi-ecosystem-group: "infrastructure"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  multi-ecosystem-group: "infrastructure"
+- package-ecosystem: "npm"
+  directory: "/"
+  groups:
+    eslint:
+      patterns:
+      - "@actions/*"
+      - "@octokit/*"
+      - "*-eslint"
+    actions-toolkit:
+      patterns:
+      - "eslint"
+      - "@eslint/*"
+      - "*-eslint"
+    vitest:
+      patterns:
+      - "vitest"
+      - "vitest-mock-extended"
+      - "@vitest/*"
     open-pull-requests-limit: 1
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
       - "vitest"
       - "vitest-mock-extended"
       - "@vitest/*"
-    open-pull-requests-limit: 1
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
+  open-pull-requests-limit: 1
+  schedule:
+    interval: "weekly"
+    day: "tuesday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,13 @@ updates:
 - package-ecosystem: "docker"
   directory: "/container-images/node/"
   multi-ecosystem-group: "infrastructure"
+  patterns:
+  - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   multi-ecosystem-group: "infrastructure"
+  patterns:
+  - "*"
 - package-ecosystem: "npm"
   directory: "/"
   groups:


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
These changes group dependabot changes, and reduce the total number of open dependabot pull requests.

## Why are these changes being made?
Every time a pull request is updated, dependabot will rebase (spending CI time). By limiting the number of PRs, we also limit the number of CI reruns.