### PR TITLE
Compare using SHAs instead of tag names

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "fuzz": "vitest run --project fuzz --coverage.thresholds false",
         "lint": "eslint",
         "pr-checks": "npm run check-types && npm run lint && npm run test && npm run bundle",
-        "run-bundle": "node dist/index.js",
+        "run-bundle": "GITHUB_REPOSITORY=AJGranowski/preceding-tag-action node dist/index.js",
         "test": "vitest run --project unit"
     },
     "dependencies": {

--- a/src/PrecedingTagAction.ts
+++ b/src/PrecedingTagAction.ts
@@ -7,6 +7,7 @@ import { throttling } from "@octokit/plugin-throttling";
 import { fetchPrecedingTag } from "./fetchPrecedingTag";
 import { GitHubAPI } from "./GitHubAPI";
 import { Input } from "./Input";
+import type { Tag } from "./types/Tag";
 
 // Do not retry if the retry time is longer than 62 minutes.
 const MAX_RETRY_TIME_SECONDS = 62 * 60;
@@ -43,7 +44,7 @@ async function main(): Promise<void> {
     });
 
     const githubAPI = new GitHubAPI(octokit, input.getRepository());
-    const precedingTag = await fetchPrecedingTag(githubAPI, input.getRef(), {
+    const precedingTag: Tag | null = await fetchPrecedingTag(githubAPI, input.getRef(), {
         filter: input.getFilter(),
         includeRef: input.getIncludeRef()
     });
@@ -52,7 +53,7 @@ async function main(): Promise<void> {
         core.setOutput("tag", input.getDefaultTag());
         core.setOutput("tag-found", false);
     } else {
-        core.setOutput("tag", precedingTag);
+        core.setOutput("tag", precedingTag.name);
         core.setOutput("tag-found", true);
     }
 }

--- a/src/types/Tag.ts
+++ b/src/types/Tag.ts
@@ -1,0 +1,6 @@
+interface Tag {
+    name: string;
+    sha: string;
+}
+
+export type { Tag };

--- a/test/GitHubAPI.test.ts
+++ b/test/GitHubAPI.test.ts
@@ -50,12 +50,24 @@ describe("GitHubAPI", () => {
 
     describe("fetchAllTags", () => {
         test("should forward tags returned from the GitHub API", async () => {
-            const expectedTags = ["tag1", "tag2", "tag3"];
+            const expectedTags = [{
+                name: "tag1",
+                sha: randomString()
+            },
+            {
+                name: "tag2",
+                sha: randomString()
+            },
+            {
+                name: "tag3",
+                sha: randomString()
+            }];
+
             const response = {
                 data: expectedTags.map((tag) => ({
-                    name: tag,
+                    name: tag.name,
                     commit: {
-                        sha: randomString()
+                        sha: tag.sha
                     }
                 }))
             };

--- a/test/PrecedingTagAction.fuzz.test.ts
+++ b/test/PrecedingTagAction.fuzz.test.ts
@@ -113,6 +113,7 @@ describe("Fuzzing PrecedingTagAction", () => {
                 status: fc.constant(200),
                 url: fc.webUrl(),
                 data: fc.record({
+                    sha: fc.string(),
                     commit: fc.record({
                         author: fc.option(fc.record({
                             date: fc.date({noInvalidDate: true}).chain((x: any) => fc.constant(x.toISOString()))

--- a/test/PrecedingTagAction.test.ts
+++ b/test/PrecedingTagAction.test.ts
@@ -119,11 +119,20 @@ describe("PrecedingTagAction", () => {
             "token": ""
         }[key]);
         (core as any).getBooleanInput = () => false;
+        (Octokit.prototype as Octokit).rest.repos.getCommit = vi.fn((x) => ({
+            data: {
+                sha: `${x}-sha`
+            }
+        })) as any;
         (Octokit.prototype as Octokit).rest.repos.listTags = vi.fn(() => Promise.resolve({
             data: []
         })) as any;
 
         await PrecedingTagAction();
+        for (const call of (core.setFailed as any).mock.calls) {
+            throw call[0];
+        }
+
         const outputs = Object.fromEntries((core.setOutput as any).mock.calls);
         expect(outputs.tag.toString()).toBe("some-default-tag");
         expect(outputs["tag-found"].toString()).toBe("false");


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
* Change `fetchAllTags` to return the tag name *and* SHA, instead of just the tag name.
* Compare refs using SHAs instead of refs.

## Why are these changes being made?
These changes make incremental progress towards #60 by using SHAs instead of refs to compare tags. This makes the comparison request easier to cache.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.