### PR TITLE
Update dependency-review.yml allowed endpoints

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,7 @@ jobs:
         disable-sudo: true
         egress-policy: block
         allowed-endpoints: >
+          api.deps.dev:443
           api.github.com:443
           api.securityscorecards.dev:443
           github.com:443


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes
Adds `api.deps.dev` to the list of allowed endpoints.

## Why are these changes being made?
This workflow is failing with a "fetch failed" error, and I think blocking this endpoint is the reason why. Allowing this endpoint should fix it.