### PR TITLE
Fix ETag cache storage bug

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -50,18 +50,18 @@ jobs:
         name: bundle
         path: ./
 
-    - name: Run Local Action
-      id: preceding-tag-local
-      uses: ./
+    - name: Run Published Action
+      id: preceding-tag-published
+      uses: AJGranowski/preceding-tag-action@3ea16c855a3573cfdf360430e863419213205de9 # v1.1.4
       with:
         include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}
         regex: ${{ matrix.regex }}
         repository: ${{ matrix.repository }}
 
-    - name: Run Published Action
-      id: preceding-tag-published
-      uses: AJGranowski/preceding-tag-action@3ea16c855a3573cfdf360430e863419213205de9 # v1.1.4
+    - name: Run Local Action
+      id: preceding-tag-local
+      uses: ./
       with:
         include-ref: ${{ matrix.include-ref }}
         ref: ${{ matrix.ref }}

--- a/src/ETagRequestCacheDB.ts
+++ b/src/ETagRequestCacheDB.ts
@@ -58,7 +58,7 @@ class ETagRequestCacheDB {
      * Returns null if a cached response does not exist.
      */
     async matchResponse(eTag: string): Promise<CachedResponse | null> {
-        const statement = this.db.prepare("SELECT response, timestamp_z_ms FROM request_response WHERE etag=? LIMIT 1");
+        const statement = this.db.prepare("SELECT response, timestamp_z_ms FROM request_response WHERE etag IN (?1, 'W/' || ?1) LIMIT 1");
         const result = statement.get(eTag);
         if (result == null || result["response"] == null || result["timestamp_z_ms"] == null) {
             return null;
@@ -82,7 +82,7 @@ class ETagRequestCacheDB {
      * Insert a network request & response.
      */
     async put(requestHash: string, eTag: string, response: object, timestampZMS: number): Promise<void> {
-        const pruneExisting = this.db.prepare("DELETE FROM request_response WHERE request_hash=? OR etag=?");
+        const pruneExisting = this.db.prepare("DELETE FROM request_response WHERE request_hash=? OR etag IN (?2, 'W/' || ?2)");
         const statement = this.db.prepare("INSERT INTO request_response (request_hash, etag, response, timestamp_z_ms) VALUES (?, ?, ?, ?)");
         pruneExisting.run(requestHash, eTag);
         statement.run(requestHash, eTag, JSON.stringify(response), Math.round(timestampZMS));
@@ -97,7 +97,7 @@ class ETagRequestCacheDB {
             "request_hash TEXT UNIQUE NOT NULL," +
             "etag TEXT UNIQUE NOT NULL," +
             "response TEXT NOT NULL," +
-            "timestamp_z_ms INTEGER," +
+            "timestamp_z_ms INTEGER NOT NULL," +
             "PRIMARY KEY (request_hash, etag)" +
             ") STRICT"
         );

--- a/src/OctokitPluginRequestCache.ts
+++ b/src/OctokitPluginRequestCache.ts
@@ -3,7 +3,7 @@ import { hash } from "crypto";
 import { join as pathJoin } from "path";
 import { mkdir } from "fs/promises";
 import type { Octokit } from "@octokit/core";
-import type { RequestParameters } from "@octokit/types";
+import type { OctokitResponse, RequestParameters } from "@octokit/types";
 
 import { ETagRequestCacheDB } from "./ETagRequestCacheDB";
 
@@ -67,6 +67,14 @@ function hashRequestParameters(requestParameters: RequestParameters): string {
     return hash("sha256", JSON.stringify(objectToHash));
 }
 
+function isNotModified(error: any): boolean {
+    return error.status === 304 && error.response != null && error.response.headers != null && error.response.headers.etag != null;
+}
+
+function isSuccessResponse(response: OctokitResponse<any, any>): boolean {
+    return response.status >= 200 && response.status < 300;
+}
+
 export function requestCache(octokit: Octokit, options: OctokitPluginRequestCacheOptions | any): OctokitPluginRequestCacheReturn {
     const optionsWithDefaults = {
         actionsCache: actionsCache,
@@ -84,13 +92,9 @@ export function requestCache(octokit: Octokit, options: OctokitPluginRequestCach
     }
 
     octokit.hook.before("request", async (options) => {
-        if (!(await optionsWithDefaults.requestCache.isOpen())) {
-            return;
-        }
-
         let cacheControl = options.headers["cache-control"];
         cacheControl = cacheControl == null ? "" : cacheControl.toString();
-        if (cacheControl.includes("no-cache")) {
+        if (!(await optionsWithDefaults.requestCache.isOpen()) || cacheControl.includes("no-cache")) {
             return;
         }
 
@@ -102,24 +106,21 @@ export function requestCache(octokit: Octokit, options: OctokitPluginRequestCach
     });
 
     octokit.hook.after("request", async (response, options) => {
-        if (!(await optionsWithDefaults.requestCache.isOpen())) {
-            return;
-        }
-
         let cacheControl = options.headers["cache-control"];
         cacheControl = cacheControl == null ? "" : cacheControl.toString();
-        if (cacheControl.includes("no-store")) {
+        if (!(await optionsWithDefaults.requestCache.isOpen()) || cacheControl.includes("no-store")) {
             return;
         }
 
-        if (response.headers.etag != null) {
-            const etagMatcher = response.headers.etag.match(/("[^"]+")/);
-            if (etagMatcher != null && etagMatcher[1] != null) {
-                const etag = etagMatcher[1];
-                const requestHash = hashRequestParameters(options);
-                optionsWithDefaults.requestCache.put(requestHash, etag, response, Date.now());
-            }
+        if (!isSuccessResponse(response)) {
+            return;
         }
+
+        if (response.headers.etag == null || response.headers.etag.length === 0) {
+            return;
+        }
+
+        optionsWithDefaults.requestCache.put(hashRequestParameters(options), response.headers.etag, response, Date.now());
     });
 
     octokit.hook.error("request", async (error: any) => {
@@ -127,25 +128,32 @@ export function requestCache(octokit: Octokit, options: OctokitPluginRequestCach
             return;
         }
 
-        if (error.status === 304 && error.response != null && error.response.headers != null && error.response.headers.etag != null) {
-            const cachedResponse = await optionsWithDefaults.requestCache.matchResponse(error.response.headers.etag);
-            if (cachedResponse != null) {
-                return cachedResponse.response;
-            }
+        if (!isNotModified(error)) {
+            throw error;
         }
 
-        throw error;
+        const cachedResponse = await optionsWithDefaults.requestCache.matchResponse(error.response.headers.etag);
+        if (cachedResponse == null) {
+            throw new AggregateError([error], "Cache miss");
+        }
+
+        return cachedResponse.response;
     });
 
     return {
         async loadCache(primaryKey: string, restoreKey: string): Promise<void> {
             await mkdir(CACHE_DIR, {recursive: true});
-            await optionsWithDefaults.actionsCache.restoreCache([pathJoin(CACHE_DIR, "*")], primaryKey, [restoreKey]);
+            if (optionsWithDefaults.actionsCache.isFeatureAvailable()) {
+                await optionsWithDefaults.actionsCache.restoreCache([pathJoin(CACHE_DIR, "*")], primaryKey, [restoreKey]);
+            }
+
             await optionsWithDefaults.requestCache.open();
         },
         async saveCache(primaryKey: string): Promise<void> {
             await optionsWithDefaults.requestCache.close();
-            await optionsWithDefaults.actionsCache.saveCache([pathJoin(CACHE_DIR, "*")], primaryKey);
+            if (optionsWithDefaults.actionsCache.isFeatureAvailable()) {
+                await optionsWithDefaults.actionsCache.saveCache([pathJoin(CACHE_DIR, "*")], primaryKey);
+            }
         }
     };
 }

--- a/test/OctokitPluginRequestCache.test.ts
+++ b/test/OctokitPluginRequestCache.test.ts
@@ -20,7 +20,8 @@ describe("OctokitPluginRequestCache", () => {
     beforeEach(() => {
         actionsCache = {
             saveCache: async () => {},
-            restoreCache: async () => {}
+            restoreCache: async () => {},
+            isFeatureAvailable: () => true
         };
         requestCacheDB = new ETagRequestCacheDB(new SQLiteDB(":memory:", {open: false}));
     });
@@ -39,8 +40,8 @@ describe("OctokitPluginRequestCache", () => {
         });
 
         const outputs = requestCache(octokit, {actionsCache: actionsCache, enable: true, requestCache: requestCacheDB});
-        expect("loadCache" in outputs).toBe(true);
-        expect("saveCache" in outputs).toBe(true);
+        expect(Object.hasOwn(outputs, "loadCache")).toBe(true);
+        expect(Object.hasOwn(outputs, "saveCache")).toBe(true);
     });
 
     test("request hooks attached", () => {


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
Store and recall ETags as they're sent without stripping the weak validator prefix, and recall them using a *slightly* more sophisticated SQL query.

## Why are these changes being made?
ETag requests should always use the exact ETag sent from the server, so we shouldn't modify ETags when storing them for later recall.

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.