### PR TITLE
Add production.cloudfront.docker.com to allowed endpoints

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -116,6 +116,7 @@ jobs:
           dl-cdn.alpinelinux.org:443
           github.com:443
           production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
           registry-1.docker.io:443
           registry.npmjs.org:443
           release-assets.githubusercontent.com:443

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,11 +62,11 @@ jobs:
             - ".github/workflows/integration-tests.yml"
             - ".github/workflows/regression-tests.yml"
 
-    - name: Check for \#skip-auto-release
+    - name: Check for !skip-auto-release
       id: commit-comment
       run: |
         case "$(git show -s --format=%b "$GITHUB_REF")" in
-          *#skip-auto-release*) echo 'skip-auto-release=true' >> "$GITHUB_OUTPUT";;
+          *!skip-auto-release*) echo 'skip-auto-release=true' >> "$GITHUB_OUTPUT";;
         esac
 
     - name: Release Source Files Changed

--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -22,6 +22,7 @@ jobs:
           dl-cdn.alpinelinux.org:443
           github.com:443
           production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
           registry-1.docker.io:443
           registry.npmjs.org:443
           release-assets.githubusercontent.com:443


### PR DESCRIPTION
<!--
❗ Read the contribution guidelines ❗ 
https://github.com/AJGranowski/preceding-tag-action/blob/main/CONTRIBUTING.md
-->

## What are these changes?
Add `production.cloudfront.docker.com` to allowed endpoints.

## Why are these changes being made?
Builds were failing because this endpoint was blocked.