### PR TITLE
Remove extra backtick on `limit-traversal-tags` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Although this project publishes version tags, I strongly recommend [pinning this
 | `token`                   | String  | `${{ github.token }}`      | Personal access token (PAT) used to fetch the tags.                                                                                                               |
 | `limit-tags`              | Number  | `100`                      | Tag fetch limit. Only tags matching `regex` count towards this limit. Increasing this may produce a more accurate result when `ref` is very far away from `HEAD`. |
 | `limit-traversal-commits` | Number  | `1000`                     | The commit traversal limit while searching for a preceding tag.                                                                                                   |
-| `limit-traversal-tags`    | Number  | `6`                        | The tag traversal limit while searching for a preceding tag. Behaves similar to `--candidates`` on `git describe`.                                                |
+| `limit-traversal-tags`    | Number  | `6`                        | The tag traversal limit while searching for a preceding tag. Behaves similar to `--candidates` on `git describe`.                                                 |
 
 ## Outputs
 | Name        | Type    | Description                                                                            |

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: "1000"
     required: false
   limit-traversal-tags:
-    description: The tag traversal limit while searching for a preceding tag. Behaves similar to `--candidates`` on `git describe`.
+    description: The tag traversal limit while searching for a preceding tag. Behaves similar to `--candidates` on `git describe`.
     default: "6"
     required: false
   ref:


### PR DESCRIPTION
## Checklist before merging
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.