### PR TITLE
Add Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,6 +54,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Docker Cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/buildkit-cache
+          key: buildkit-${{ runner.os }}-${{ hashFiles('./container-images/**') }}
+
+      - name: Build Docker images
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          allow: |
+            network.host
+          builder: ${{ steps.setup-buildx-action.outputs.name }}
+          load: true
+          set: |
+            *.cache-from=type=local,src=/tmp/buildkit-cache
+            *.cache-to=type=local,dest=/tmp/buildkit-cache,mode=max
+          source: .
+
       - name: Build an images
         run: docker compose build
 
@@ -68,7 +86,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: SARIF file
+          name: SARIF file ${{ matrix.image }}
           path: trivy-results.sarif
           retention-days: 5
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,43 @@
+name: Trivy security scanner
+on:
+  schedule:
+    - cron: '16 8 * * 6'
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # Required to checkout and read repo files
+      security-events: write  # Required to upload SARIF files to Security tab
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: "Checkout code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,7 +1,7 @@
 name: Trivy security scanner
 on:
   schedule:
-    - cron: '16 8 * * 6'
+    - cron: "16 8 * * 6"
   push:
     branches: [ "main" ]
   pull_request:
@@ -95,10 +95,10 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: '${{ matrix.image }}'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL'
+          image-ref: "${{ matrix.image }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL"
       
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,7 +20,9 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,7 +49,15 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            check.trivy.dev:443
+            dl-cdn.alpinelinux.org:443
+            github.com:443
+            production.cloudfront.docker.com:443
+            registry-1.docker.io:443
 
       - name: "Checkout code"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,8 @@ jobs:
   index-images:
     name: Index Images
     runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.images.outputs.json }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,14 +28,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run Trivy vulnerability scanner in repo mode
+      - name: Build an images from compose
+        id: images
+        run: |
+          docker compose build
+          echo "image=$(docker compose config --images | head -n 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          scan-type: "fs"
-          ignore-unfixed: true
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
+          image-ref: '${{ steps.images.outputs.image }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
+      - name: Set up Docker CLI
+        id: setup-buildx-action
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: ci
+
       - name: Docker Cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,6 +40,13 @@ jobs:
           image-ref: '${{ steps.images.outputs.image }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
+      
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: trivy-results.sarif
+          retention-days: 5
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -69,7 +69,7 @@ jobs:
         id: setup-buildx-action
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          name: ci
+          name: trivy
 
       - name: Docker Cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,12 +10,9 @@ on:
 permissions: read-all
 
 jobs:
-  build:
-    name: Build
+  index-images:
+    name: Index Images
     runs-on: ubuntu-latest
-    permissions:
-      contents: read          # Required to checkout and read repo files
-      security-events: write  # Required to upload SARIF files to Security tab
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -28,18 +25,43 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build an images from compose
+      - name: Collect all compose image names
         id: images
-        run: |
-          docker compose build
-          echo "image=$(docker compose config --images | head -n 1)" >> "$GITHUB_OUTPUT"
+        run: echo "json=$(docker compose config --images | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: index-images
+    permissions:
+      contents: read          # Required to checkout and read repo files
+      security-events: write  # Required to upload SARIF files to Security tab
+    strategy:
+      matrix:
+        image: ${{ fromJSON(needs.index-images.outputs.json) }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: "Checkout code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build an images
+        run: docker compose build
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: '${{ steps.images.outputs.image }}'
+          image-ref: '${{ matrix.image }}'
           format: 'sarif'
           output: 'trivy-results.sarif'
+          severity: 'CRITICAL'
       
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What are these changes?
Add a [Trivy](https://github.com/aquasecurity/trivy-action) workflow, ideally to scan Dockerfiles, but we'll see.

## Why are these changes being made?
Probably a good idea to have vulnerability scanning for this project's Dockerfile.