### PR TITLE
Limit sarif output

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -96,8 +96,9 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: "${{ matrix.image }}"
           format: "sarif"
+          image-ref: "${{ matrix.image }}"
+          limit-severities-for-sarif: true
           output: "trivy-results.sarif"
           severity: "CRITICAL"
       


### PR DESCRIPTION
## What are these changes?
Limit the sarif output to just critical detections.

## Why are these changes being made?
I don't have fine control over the base image of the toolchain for this project. When I get a vulnerability alert for an image, I want to be actionable: something I can fix either by using a previous image version or by bumping to a new image version. Hopefully setting this to critical limits the noise while still remaining useful.