### PR TITLE
Bump undici, nanoid, and postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3331,9 +3331,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.17",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
             "dev": true,
             "funding": [
                 {
@@ -3480,9 +3480,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.19",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "dev": true,
             "funding": [
                 {
@@ -3500,7 +3500,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,9 +3809,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"


### PR DESCRIPTION
## What are these changes?
Bump a few packages in `package-lock`.

## Why are these changes being made?
This change addresses some raised security issues:
* https://github.com/AJGranowski/preceding-tag-action/security/dependabot/47
* https://github.com/AJGranowski/preceding-tag-action/security/dependabot/48
* https://github.com/AJGranowski/preceding-tag-action/security/dependabot/49
* https://github.com/AJGranowski/preceding-tag-action/security/dependabot/50

## Checklist before merging
- [X] `./npm run check-types` succeeds.
- [X] `./npm run lint` succeeds.
- [X] `./npm run test` succeeds.
- [X] `./npm run bundle` succeeds.
- [X] Inputs, outputs, and descriptions of `README.md` and `action.yml` match.